### PR TITLE
Add Spinner component and show it on Auth loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Loader } from 'lucide-react';
+
+interface SpinnerProps {
+  size?: number;
+  className?: string;
+}
+
+const Spinner: React.FC<SpinnerProps> = ({ size = 24, className = '' }) => (
+  <Loader size={size} className={`animate-spin ${className}`} />
+);
+
+export default Spinner;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -5,6 +5,7 @@ import AuthForm from '../components/ui/AuthForm';
 import CompanyForm from '../components/ui/CompanyForm';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
+import Spinner from '../components/ui/Spinner';
 import { Building2 } from 'lucide-react';
 
 const Auth: React.FC = () => {
@@ -14,7 +15,7 @@ const Auth: React.FC = () => {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-pulse">Loading...</div>
+        <Spinner size={32} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- create a simple `Spinner` UI component
- show the new spinner when the authentication page is loading
- ignore `node_modules` and build output

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889c711a62083258fc35b9f536ec9c9