### PR TITLE
Translate auth screens to French

### DIFF
--- a/src/components/ui/AuthForm.tsx
+++ b/src/components/ui/AuthForm.tsx
@@ -47,11 +47,11 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode }) => {
             id="email"
             type="email"
             className={`form-input pl-10 ${errors.email ? 'border-error' : ''}`}
-            {...register('email', { 
-              required: 'Email is required',
+              {...register('email', {
+              required: "L'email est requis",
               pattern: {
                 value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-                message: 'Invalid email address'
+                message: 'Adresse e-mail invalide'
               }
             })}
           />
@@ -64,18 +64,18 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode }) => {
 
       <div>
         <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
-          Password
+          Mot de passe
         </label>
         <div className="relative">
           <input
             id="password"
             type="password"
             className={`form-input pl-10 ${errors.password ? 'border-error' : ''}`}
-            {...register('password', { 
-              required: 'Password is required',
+            {...register('password', {
+              required: 'Le mot de passe est requis',
               minLength: {
                 value: 8,
-                message: 'Password must be at least 8 characters'
+                message: 'Le mot de passe doit contenir au moins 8 caract\u00e8res'
               }
             })}
           />
@@ -93,7 +93,7 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode }) => {
         disabled={isSubmitting}
         icon={isSubmitting ? <Loader className="animate-spin" size={16} /> : undefined}
       >
-        {isSubmitting ? 'Processing...' : mode === 'signin' ? 'Sign In' : 'Sign Up'}
+        {isSubmitting ? 'Traitement...' : mode === 'signin' ? 'Se connecter' : "S'inscrire"}
       </Button>
     </form>
   );

--- a/src/components/ui/CompanyForm.tsx
+++ b/src/components/ui/CompanyForm.tsx
@@ -67,12 +67,12 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            First Name
+            Prénom
           </label>
           <input
             type="text"
             className={`form-input ${errors.user_first_name ? 'border-error' : ''}`}
-            {...register('user_first_name', { required: 'First name is required' })}
+            {...register('user_first_name', { required: 'Le prénom est requis' })}
           />
           {errors.user_first_name && (
             <p className="mt-1 text-sm text-error">{errors.user_first_name.message}</p>
@@ -81,12 +81,12 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Last Name
+            Nom
           </label>
           <input
             type="text"
             className={`form-input ${errors.user_last_name ? 'border-error' : ''}`}
-            {...register('user_last_name', { required: 'Last name is required' })}
+            {...register('user_last_name', { required: 'Le nom est requis' })}
           />
           {errors.user_last_name && (
             <p className="mt-1 text-sm text-error">{errors.user_last_name.message}</p>
@@ -96,12 +96,12 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
 
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-1">
-          Company Name
+          Nom de l'entreprise
         </label>
         <input
           type="text"
           className={`form-input ${errors.name ? 'border-error' : ''}`}
-          {...register('name', { required: 'Company name is required' })}
+          {...register('name', { required: "Le nom de l'entreprise est requis" })}
         />
         {errors.name && (
           <p className="mt-1 text-sm text-error">{errors.name.message}</p>
@@ -110,7 +110,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
 
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-1">
-          Legal Name
+          Raison sociale
         </label>
         <input
           type="text"
@@ -130,7 +130,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
             {...register('siren', {
               pattern: {
                 value: /^\d{9}$/,
-                message: 'SIREN must be 9 digits'
+                message: 'Le SIREN doit comporter 9 chiffres'
               }
             })}
           />
@@ -141,7 +141,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            VAT Number
+            Numéro de TVA
           </label>
           <input
             type="text"
@@ -153,7 +153,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
 
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-1">
-          Address
+          Adresse
         </label>
         <input
           type="text"
@@ -165,7 +165,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="col-span-1">
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Postal Code
+            Code postal
           </label>
           <input
             type="text"
@@ -176,7 +176,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
 
         <div className="col-span-1 md:col-span-2">
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            City
+            Ville
           </label>
           <input
             type="text"
@@ -187,7 +187,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
 
         <div className="col-span-2 md:col-span-1">
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Country
+            Pays
           </label>
           <input
             type="text"
@@ -209,7 +209,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
             {...register('email', {
               pattern: {
                 value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-                message: 'Invalid email address'
+                message: 'Adresse e-mail invalide'
               }
             })}
           />
@@ -220,7 +220,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Phone
+            Téléphone
           </label>
           <input
             type="tel"
@@ -237,7 +237,7 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
         disabled={isSubmitting}
         icon={isSubmitting ? <Loader className="animate-spin" size={16} /> : <Building2 size={16} />}
       >
-        {isSubmitting ? 'Creating company...' : 'Create Company'}
+        {isSubmitting ? "Cr\u00e9ation de l'entreprise..." : "Cr\u00e9er l'entreprise"}
       </Button>
     </form>
   );

--- a/src/components/ui/SearchInput.tsx
+++ b/src/components/ui/SearchInput.tsx
@@ -116,7 +116,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
             ${size === 'sm' ? 'right-2' : size === 'lg' ? 'right-4' : 'right-3'}
             focus:outline-none focus-visible:ring-2 focus-visible:ring-primary
           `}
-          aria-label="Clear search"
+          aria-label="Effacer la recherche"
         >
           <X size={getIconSize()} />
         </button>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -14,7 +14,7 @@ const Auth: React.FC = () => {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-pulse">Loading...</div>
+        <div className="animate-pulse">Chargement...</div>
       </div>
     );
   }
@@ -34,10 +34,10 @@ const Auth: React.FC = () => {
               <Building2 size={24} className="text-white" />
             </div>
             <h2 className="mt-6 text-3xl font-bold text-gray-900">
-              Set up your company
+              Configurez votre entreprise
             </h2>
             <p className="mt-2 text-sm text-gray-600">
-              Enter your company details to get started
+              Saisissez les informations de votre entreprise pour commencer
             </p>
           </div>
 
@@ -57,12 +57,12 @@ const Auth: React.FC = () => {
             <Building2 size={24} className="text-white" />
           </div>
           <h2 className="mt-6 text-3xl font-bold text-gray-900">
-            {mode === 'signin' ? 'Welcome back' : 'Create your account'}
+            {mode === 'signin' ? 'Ravi de vous revoir' : 'Créez votre compte'}
           </h2>
           <p className="mt-2 text-sm text-gray-600">
-            {mode === 'signin' 
-              ? 'Sign in to your account to continue' 
-              : 'Get started with your free account'}
+            {mode === 'signin'
+              ? 'Connectez-vous à votre compte pour continuer'
+              : 'Commencez avec votre compte gratuit'}
           </p>
         </div>
 
@@ -71,13 +71,13 @@ const Auth: React.FC = () => {
           
           <div className="mt-4 text-center">
             <p className="text-sm text-gray-600">
-              {mode === 'signin' ? "Don't have an account? " : 'Already have an account? '}
+              {mode === 'signin' ? 'Pas encore de compte ? ' : 'Vous avez d\u00e9j\u00e0 un compte ? '}
               <Button 
                 variant="text" 
                 size="sm" 
                 onClick={() => setMode(mode === 'signin' ? 'signup' : 'signin')}
               >
-                {mode === 'signin' ? 'Sign up' : 'Sign in'}
+                {mode === 'signin' ? "S'inscrire" : 'Se connecter'}
               </Button>
             </p>
           </div>


### PR DESCRIPTION
## Summary
- translate authentication UI to French
- update company creation form labels and errors to French
- translate search input aria label

## Testing
- `npm run lint` *(fails: 86 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6889ddf14b84832582e7386e43de30c5