### PR TITLE
Add Vitest configuration and initial test

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ The app will be available at `http://localhost:5173` by default.
   ```
   Runs ESLint on the project sources.
 - **Test:**
-  There are currently no automated tests configured, so no test command is provided.
+  ```bash
+  npm test
+  ```
+  Runs the Vitest test suite.
 
 ## Environment variables
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -34,6 +35,9 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.3.1",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import App from '../App';
+
+// Mock AuthProvider to avoid Supabase calls
+vi.mock('../contexts/AuthContext', () => {
+  const React = require('react');
+  return { AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</> };
+});
+
+describe('<App />', () => {
+  it('renders without crashing', () => {
+    render(<App />);
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
@@ -6,5 +6,10 @@ export default defineConfig({
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/setupTests.ts',
   },
 });


### PR DESCRIPTION
## Summary
- configure Vitest in `vite.config.ts`
- add testing dependencies and script in `package.json`
- document test command in README
- provide basic test for `<App />` rendering
- add test setup importing jest-dom

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889ddf3e06c83258f4b54b7afe82f1d