### PR TITLE
Add aria labels to alert icons

### DIFF
--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -32,6 +32,19 @@ const Alert: React.FC<AlertProps> = ({
     }
   };
 
+  const getIconLabel = () => {
+    switch (variant) {
+      case 'success':
+        return 'Success alert';
+      case 'warning':
+        return 'Warning alert';
+      case 'error':
+        return 'Error alert';
+      default:
+        return 'Information alert';
+    }
+  };
+
   const getStyles = () => {
     const baseStyles = 'rounded-lg p-4 flex items-start';
     switch (variant) {
@@ -48,7 +61,11 @@ const Alert: React.FC<AlertProps> = ({
 
   return (
     <div className={getStyles()}>
-      <div className="flex-shrink-0 mr-3">{getIcon()}</div>
+      <div className="flex-shrink-0 mr-3">
+        <span role="img" aria-label={getIconLabel()}>
+          {getIcon()}
+        </span>
+      </div>
       <div className="flex-1 min-w-0">
         {title && (
           <h4 className="text-sm font-medium mb-1">{title}</h4>

--- a/src/components/ui/BudgetProgress.tsx
+++ b/src/components/ui/BudgetProgress.tsx
@@ -18,6 +18,25 @@ const BudgetProgress: React.FC<BudgetProgressProps> = ({
   const remaining = budget - spent;
   const isOverBudget = spent > budget;
 
+  const getStatusIcon = () => {
+    if (isOverBudget) {
+      return {
+        icon: <AlertTriangle size={16} className="text-error mr-1" />,
+        label: 'Over budget',
+      };
+    }
+    if (percentage >= 90) {
+      return {
+        icon: <TrendingUp size={16} className="text-warning mr-1" />,
+        label: 'Nearing budget limit',
+      };
+    }
+    return {
+      icon: <CheckCircle size={16} className="text-success mr-1" />,
+      label: 'Within budget',
+    };
+  };
+
   return (
     <div className="p-4 border border-gray-200 rounded-lg">
       <div className="flex items-center justify-between mb-2">
@@ -37,16 +56,13 @@ const BudgetProgress: React.FC<BudgetProgressProps> = ({
             </span>
           </div>
           <div className="flex items-center">
-            {isOverBudget ? (
-              <AlertTriangle size={16} className="text-error mr-1" />
-            ) : percentage >= 90 ? (
-              <TrendingUp size={16} className="text-warning mr-1" />
-            ) : (
-              <CheckCircle size={16} className="text-success mr-1" />
-            )}
+            {(() => {
+              const { icon, label } = getStatusIcon();
+              return <span role="img" aria-label={label}>{icon}</span>;
+            })()}
             <span className={`text-xs font-semibold inline-block ${
-              isOverBudget ? 'text-error' : 
-              percentage >= 90 ? 'text-warning' : 
+              isOverBudget ? 'text-error' :
+              percentage >= 90 ? 'text-warning' :
               'text-success'
             }`}>
               {percentage.toFixed(1)}%

--- a/src/components/ui/KPICard.tsx
+++ b/src/components/ui/KPICard.tsx
@@ -39,6 +39,17 @@ const KPICard: React.FC<KPICardProps> = ({
     }
   };
 
+  const getTrendLabel = () => {
+    switch (trend) {
+      case 'up':
+        return 'Increasing';
+      case 'down':
+        return 'Decreasing';
+      default:
+        return '';
+    }
+  };
+
   return (
     <Card className="p-6">
       <h3 className="text-sm font-medium text-gray-500">{title}</h3>
@@ -46,7 +57,9 @@ const KPICard: React.FC<KPICardProps> = ({
         <p className="text-2xl font-semibold text-gray-900">{value}</p>
         {change !== undefined && (
           <p className={`ml-2 flex items-center text-sm ${getTrendColor()}`}>
-            {getTrendIcon()}
+            {getTrendIcon() && (
+              <span role="img" aria-label={getTrendLabel()}>{getTrendIcon()}</span>
+            )}
             <span className="ml-1">{Math.abs(change)}%</span>
           </p>
         )}

--- a/src/components/ui/NotificationCenter.tsx
+++ b/src/components/ui/NotificationCenter.tsx
@@ -39,19 +39,40 @@ const NotificationCenter: React.FC = () => {
     }
   ]);
 
-  const getIcon = (type: string) => {
+  const getIconLabel = (type: string) => {
     switch (type) {
       case 'info':
-        return <InfoIcon size={18} className="text-primary" />;
+        return 'Information notification';
       case 'success':
-        return <CheckCircle size={18} className="text-success" />;
+        return 'Success notification';
       case 'warning':
-        return <AlertTriangle size={18} className="text-warning" />;
+        return 'Warning notification';
       case 'error':
-        return <AlertTriangle size={18} className="text-error" />;
+        return 'Error notification';
       default:
-        return <InfoIcon size={18} className="text-primary" />;
+        return 'Information notification';
     }
+  };
+
+  const getIcon = (type: string) => {
+    let icon;
+    switch (type) {
+      case 'info':
+        icon = <InfoIcon size={18} className="text-primary" />;
+        break;
+      case 'success':
+        icon = <CheckCircle size={18} className="text-success" />;
+        break;
+      case 'warning':
+        icon = <AlertTriangle size={18} className="text-warning" />;
+        break;
+      case 'error':
+        icon = <AlertTriangle size={18} className="text-error" />;
+        break;
+      default:
+        icon = <InfoIcon size={18} className="text-primary" />;
+    }
+    return <span role="img" aria-label={getIconLabel(type)}>{icon}</span>;
   };
 
   const markAllAsRead = () => {
@@ -111,7 +132,9 @@ const NotificationCenter: React.FC = () => {
             <button
               onClick={() => setIsOpen(false)}
               className="p-1 rounded-full hover:bg-gray-100"
+              aria-label="Close notifications"
             >
+              <span className="sr-only">Close</span>
               <X size={20} />
             </button>
           </div>
@@ -120,7 +143,7 @@ const NotificationCenter: React.FC = () => {
         <div className="overflow-y-auto h-full pb-16">
           {notifications.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-full text-gray-500">
-              <Bell size={48} className="mb-3 opacity-20" />
+              <Bell size={48} className="mb-3 opacity-20" aria-hidden="true" />
               <p>Aucune notification</p>
             </div>
           ) : (
@@ -148,7 +171,9 @@ const NotificationCenter: React.FC = () => {
                           <button
                             onClick={() => deleteNotification(notification.id)}
                             className="ml-2 text-gray-400 hover:text-gray-600"
+                            aria-label="Delete notification"
                           >
+                            <span className="sr-only">Delete</span>
                             <X size={14} />
                           </button>
                         </div>
@@ -169,6 +194,7 @@ const NotificationCenter: React.FC = () => {
         <button
           onClick={() => setIsOpen(true)}
           className="fixed bottom-20 md:bottom-6 right-6 bg-primary text-white rounded-full p-3 shadow-lg hover:bg-primary-light transition-colors z-30"
+          aria-label="Open notifications"
         >
           <Bell size={20} />
           <span className="absolute -top-1 -right-1 w-5 h-5 bg-accent rounded-full flex items-center justify-center text-xs text-white">

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -30,6 +30,19 @@ const Toast: React.FC<ToastProps> = ({ id, message, type, onClose }) => {
     }
   };
 
+  const getIconLabel = () => {
+    switch (type) {
+      case 'success':
+        return 'Success alert';
+      case 'error':
+        return 'Error alert';
+      case 'warning':
+        return 'Warning alert';
+      case 'info':
+        return 'Information alert';
+    }
+  };
+
   const getStyles = () => {
     const baseStyles = 'flex items-center w-full max-w-xs p-4 mb-4 rounded-lg shadow';
     switch (type) {
@@ -47,7 +60,9 @@ const Toast: React.FC<ToastProps> = ({ id, message, type, onClose }) => {
   return (
     <div className={getStyles()} role="alert">
       <div className="inline-flex items-center justify-center flex-shrink-0 w-8 h-8">
-        {getIcon()}
+        <span role="img" aria-label={getIconLabel()}>
+          {getIcon()}
+        </span>
       </div>
       <div className="ml-3 text-sm font-normal">{message}</div>
       <button


### PR DESCRIPTION
## Summary
- make Toast icons screen-reader friendly
- improve NotificationCenter accessibility
- label icons for Alert, KPI, and budget progress components

## Testing
- `npm run lint` *(fails: no-unused-vars errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6889ddf310e083259458e3115a98ac16