### PR TITLE
Fix syntax markers in Popover component

### DIFF
--- a/src/components/ui/Popover.tsx
+++ b/src/components/ui/Popover.tsx
@@ -1,4 +1,3 @@
-```typescript
 import React, { useState, useRef, useEffect } from 'react';
 
 interface PopoverProps {
@@ -101,4 +100,3 @@ const Popover: React.FC<PopoverProps> = ({
 };
 
 export default Popover;
-```


### PR DESCRIPTION
## Summary
- remove stray markdown fences from `Popover.tsx`

## Testing
- `node - <<'NODE'
const ts=require('typescript');
const fs=require('fs');
const source=fs.readFileSync('src/components/ui/Popover.tsx','utf8');
const result=ts.transpileModule(source,{compilerOptions:{jsx:'react'}});
console.log('success');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_688a0d29097083258e8408358abbe093