### PR TITLE
Add jsdom dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",


### PR DESCRIPTION
## Summary
- include jsdom in devDependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cssstyle)*
- `npm test` *(fails: MISSING DEPENDENCY Cannot find dependency 'jsdom')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688a0d2a61e48325954b5f7a8938163a