### PR TITLE
Fix tests by adding environment and polyfill

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=http://localhost
+VITE_SUPABASE_ANON_KEY=anon-key

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -31,7 +31,8 @@ const Button: React.FC<ButtonProps> = ({
   disabled = false,
   onClick,
   className = '',
-  type = 'button'
+  type = 'button',
+  ariaLabel
 }) => {
   const getVariantClasses = () => {
     switch (variant) {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom';
+
+// Polyfill ResizeObserver for recharts components in tests
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).ResizeObserver = ResizeObserver;
+
+// Mock scrollIntoView used in MaxAssistant component
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).HTMLElement.prototype.scrollIntoView = () => {};


### PR DESCRIPTION
## Summary
- add `.env.test` so Supabase client initializes during tests
- allow `ariaLabel` prop in `Button`
- polyfill `ResizeObserver` and `scrollIntoView` for Vitest

## Testing
- `npm test`
- `npm run lint` *(fails: 103 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688a204795708325a3f18a1313cee1dc