### PR TITLE
Persist sidebar open state

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -10,7 +10,12 @@ interface LayoutProps {
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   const [isMobile, setIsMobile] = useState(false);
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
+    if (typeof window !== 'undefined') {
+      return JSON.parse(localStorage.getItem('sidebarOpen') || 'false');
+    }
+    return false;
+  });
 
   useEffect(() => {
     const checkMobile = () => {
@@ -24,6 +29,12 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       window.removeEventListener('resize', checkMobile);
     };
   }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('sidebarOpen', JSON.stringify(sidebarOpen));
+    }
+  }, [sidebarOpen]);
 
   const toggleSidebar = () => {
     setSidebarOpen(!sidebarOpen);


### PR DESCRIPTION
## Summary
- remember sidebar toggle state with localStorage

## Testing
- `npm run lint` *(fails: 98 errors, 5 warnings)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b3281849883258846a56b6df2316d