### PR TITLE
Add toast examples and notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
+import { ToastProvider } from './contexts/ToastContext';
 import Layout from './components/layout/Layout';
 import Auth from './pages/Auth';
 import Dashboard from './pages/Dashboard';
@@ -27,13 +28,15 @@ const App: React.FC = () => (
     </h1>
 
     <Router>
-      <AuthProvider>
-        <Routes>
-          <Route path="/auth" element={<Auth />} />
-          <Route path="/" element={<Layout><Dashboard /></Layout>} />
-          {/* … autres routes */}
-        </Routes>
-      </AuthProvider>
+      <ToastProvider>
+        <AuthProvider>
+          <Routes>
+            <Route path="/auth" element={<Auth />} />
+            <Route path="/" element={<Layout><Dashboard /></Layout>} />
+            {/* … autres routes */}
+          </Routes>
+        </AuthProvider>
+      </ToastProvider>
     </Router>
   </div>
 );

--- a/src/components/ui/AuthForm.tsx
+++ b/src/components/ui/AuthForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import Button from './Button';
 import { supabase } from '../../lib/supabase';
 import { Mail, Lock, Loader } from 'lucide-react';
+import { useToast } from '../../contexts/ToastContext';
 
 interface AuthFormProps {
   mode: 'signin' | 'signup';
@@ -15,6 +16,7 @@ interface FormData {
 
 const AuthForm: React.FC<AuthFormProps> = ({ mode }) => {
   const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormData>();
+  const { addToast } = useToast();
 
   const onSubmit = async (data: FormData) => {
     try {
@@ -24,15 +26,19 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode }) => {
           password: data.password,
         });
         if (error) throw error;
+        addToast('Connexion réussie', 'success');
       } else {
         const { error } = await supabase.auth.signUp({
           email: data.email,
           password: data.password,
         });
         if (error) throw error;
+        addToast('Inscription réussie', 'success');
       }
     } catch (error) {
       console.error('Authentication error:', error);
+      const message = (error as Error).message || 'Erreur lors de lauthentification';
+      addToast(message, 'warning');
     }
   };
 

--- a/src/components/ui/CompanyForm.tsx
+++ b/src/components/ui/CompanyForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import Button from './Button';
 import { supabase } from '../../lib/supabase';
 import { Building2, Loader } from 'lucide-react';
+import { useToast } from '../../contexts/ToastContext';
 import type { Database } from '../../lib/database.types';
 
 type CompanyInsert = Database['public']['Tables']['companies']['Insert'];
@@ -20,6 +21,7 @@ interface CompanyFormProps {
 
 const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
   const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<CompanyFormData>();
+  const { addToast } = useToast();
 
   const onSubmit = async (data: CompanyFormData) => {
     try {
@@ -56,9 +58,12 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
 
       if (userError) throw userError;
 
+      addToast("Entreprise créée avec succès", 'success');
       onSuccess();
     } catch (error) {
       console.error('Error creating company:', error);
+      const message = (error as Error).message || "Erreur lors de la création de l'entreprise";
+      addToast(message, 'warning');
     }
   };
 

--- a/src/lib/hooks/useSupabaseQuery.ts
+++ b/src/lib/hooks/useSupabaseQuery.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../supabase';
 import type { PostgrestError } from '@supabase/supabase-js';
+import { useToast } from '../../contexts/ToastContext';
 
 export function useSupabaseQuery<T>(
   query: () => Promise<{ data: T | null; error: PostgrestError | null }>,
@@ -9,6 +10,7 @@ export function useSupabaseQuery<T>(
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<PostgrestError | null>(null);
   const [loading, setLoading] = useState(true);
+  const { addToast } = useToast();
 
   useEffect(() => {
     async function fetchData() {
@@ -18,9 +20,11 @@ export function useSupabaseQuery<T>(
         if (error) throw error;
         setData(data);
         setError(null);
+        addToast('Données chargées', 'success');
       } catch (err) {
         setError(err as PostgrestError);
         setData(null);
+        addToast('Erreur lors du chargement des données', 'warning');
       } finally {
         setLoading(false);
       }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import Charts from '../components/ui/Charts';
 import MaxAssistant from '../components/ui/MaxAssistant';
+import { useToast } from '../contexts/ToastContext';
 import { 
   Wallet,
   TrendingUp,
@@ -27,6 +28,7 @@ import {
 
 const Dashboard: React.FC = () => {
   const navigate = useNavigate();
+  const { addToast } = useToast();
   // Sample data for cash flow chart
   const cashFlowData = [
     { date: '01/07', inflow: 45000, outflow: 32000, balance: 13000 },
@@ -100,6 +102,14 @@ const Dashboard: React.FC = () => {
 
   return (
     <div className="animate-slide-in-up">
+      <div className="mb-4">
+        <Button
+          variant="secondary"
+          onClick={() => addToast('Exemple de toast', 'success')}
+        >
+          Tester les toasts
+        </Button>
+      </div>
       {/* Floating Quick Actions Menu */}
       <div className="fixed top-24 right-6 z-40 space-y-2">
         {quickActions.map((action, index) => (


### PR DESCRIPTION
## Summary
- show toasts when signing in or signing up
- display toast after creating a company
- expose toast API in the Supabase query hook
- wrap `App` with `ToastProvider`
- demo toast on the Dashboard page

## Testing
- `npm run lint` *(fails: 103 problems)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b3280482c8325b03571963b42a777