### PR TITLE
Add Escape key handling in overlays

### DIFF
--- a/src/components/ui/MaxAssistant.tsx
+++ b/src/components/ui/MaxAssistant.tsx
@@ -18,6 +18,8 @@ const MaxAssistant: React.FC = () => {
   const [isTyping, setIsTyping] = useState(false);
   const [showWelcome, setShowWelcome] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const openButtonRef = useRef<HTMLButtonElement>(null);
+  const wasOpen = useRef(false);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -26,6 +28,20 @@ const MaxAssistant: React.FC = () => {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
 
   // Simulate initial greeting with personality
   useEffect(() => {
@@ -43,6 +59,13 @@ const MaxAssistant: React.FC = () => {
         setIsTyping(false);
       }, 1000);
     }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (wasOpen.current && !isOpen) {
+      openButtonRef.current?.focus();
+    }
+    wasOpen.current = isOpen;
   }, [isOpen]);
 
   const handleSend = () => {
@@ -106,6 +129,7 @@ const MaxAssistant: React.FC = () => {
       {/* Floating button with animation */}
       {!isOpen && (
         <button
+          ref={openButtonRef}
           onClick={() => setIsOpen(true)}
           className="fixed bottom-6 right-6 bg-primary text-white rounded-full p-4 shadow-lg hover:bg-primary-light transition-all duration-300 z-50 group animate-bounce hover:animate-none"
         >

--- a/src/components/ui/NotificationCenter.tsx
+++ b/src/components/ui/NotificationCenter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { X, Bell, CheckCircle, AlertTriangle, InfoIcon } from 'lucide-react';
 
 interface Notification {
@@ -12,6 +12,8 @@ interface Notification {
 
 const NotificationCenter: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const openButtonRef = useRef<HTMLButtonElement>(null);
+  const wasOpen = useRef(false);
   const [notifications, setNotifications] = useState<Notification[]>([
     {
       id: '1',
@@ -106,6 +108,27 @@ const NotificationCenter: React.FC = () => {
 
   const unreadCount = notifications.filter(n => !n.read).length;
 
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (wasOpen.current && !isOpen) {
+      openButtonRef.current?.focus();
+    }
+    wasOpen.current = isOpen;
+  }, [isOpen]);
+
   return (
     <>
       {isOpen && (
@@ -192,6 +215,7 @@ const NotificationCenter: React.FC = () => {
       
       {!isOpen && unreadCount > 0 && (
         <button
+          ref={openButtonRef}
           onClick={() => setIsOpen(true)}
           className="fixed bottom-20 md:bottom-6 right-6 bg-primary text-white rounded-full p-3 shadow-lg hover:bg-primary-light transition-colors z-30"
           aria-label="Open notifications"


### PR DESCRIPTION
## Summary
- close `NotificationCenter` and `MaxAssistant` on Escape
- return focus to the opening button when overlays close

## Testing
- `npm run lint` *(fails: 103 problems)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b327ea518832582b27d947f952982