### PR TITLE
Add toast notifications

### DIFF
--- a/src/components/ui/AuthForm.tsx
+++ b/src/components/ui/AuthForm.tsx
@@ -36,7 +36,8 @@ const AuthForm: React.FC<AuthFormProps> = ({ mode }) => {
         addToast('Inscription réussie', 'success');
       }
     } catch (error) {
-      addToast("Message d'erreur", 'error');
+      const message = (error as Error).message || "Erreur lors de l'authentification";
+      addToast(message, 'error');
     }
   };
 

--- a/src/components/ui/CompanyForm.tsx
+++ b/src/components/ui/CompanyForm.tsx
@@ -7,7 +7,6 @@ import type { Database } from '../../lib/database.types';
 import { useToast } from '../../contexts/ToastContext';
 
 type CompanyInsert = Database['public']['Tables']['companies']['Insert'];
-type UserUpdate = Database['public']['Tables']['users']['Update'];
 
 interface CompanyFormData extends Omit<CompanyInsert, 'id' | 'created_at' | 'updated_at'> {
   user_first_name: string;
@@ -61,7 +60,8 @@ const CompanyForm: React.FC<CompanyFormProps> = ({ userId, onSuccess }) => {
       onSuccess();
       addToast('Entreprise créée avec succès', 'success');
     } catch (error) {
-      addToast("Message d'erreur", 'error');
+      const message = (error as Error).message || "Erreur lors de la création";
+      addToast(message, 'error');
     }
   };
 


### PR DESCRIPTION
## Summary
- integrate `useToast` into AuthForm and CompanyForm
- display success notifications when sign up or creating company
- show error toast instead of console logging

## Testing
- `npm run lint` *(fails: 105 problems)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b327cac808325bd8faea693d7372d