### PR TITLE
Fix recharts container sizes

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -12,10 +12,18 @@ vi.mock('../contexts/AuthContext', () => {
 
 describe('<App />', () => {
   it('renders without crashing', () => {
-    render(
+    const div = document.createElement('div');
+    div.style.width = '1024px';
+    div.style.height = '768px';
+    Object.defineProperty(div, 'offsetWidth', { configurable: true, value: 1024 });
+    Object.defineProperty(div, 'offsetHeight', { configurable: true, value: 768 });
+
+    const { container } = render(
       <ThemeProvider>
         <App />
-      </ThemeProvider>
+      </ThemeProvider>,
+      { container: div }
     );
+    document.body.appendChild(container);
   });
 });

--- a/src/components/ui/BudgetChart.tsx
+++ b/src/components/ui/BudgetChart.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  ResponsiveContainer,
   PieChart,
   Pie,
   Cell,
@@ -14,11 +13,15 @@ interface BudgetChartProps {
     value: number;
     color: string;
   }[];
+  /** Width of the chart container. Defaults to 400 */
+  width?: number;
+  /** Height of the chart container. Defaults to 300 */
   height?: number;
 }
 
 const BudgetChart: React.FC<BudgetChartProps> = ({
   data,
+  width = 400,
   height = 300
 }) => {
   const renderTooltip = ({ active, payload }: any) => {
@@ -43,34 +46,30 @@ const BudgetChart: React.FC<BudgetChartProps> = ({
   }));
 
   return (
-    <div style={{ width: '100%', height }}>
-      <ResponsiveContainer>
-        <PieChart>
-          <Pie
-            data={dataWithPercentage}
-            cx="50%"
-            cy="50%"
-            innerRadius={60}
-            outerRadius={80}
-            paddingAngle={5}
-            dataKey="value"
-          >
-            {dataWithPercentage.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={entry.color} />
-            ))}
-          </Pie>
-          <Tooltip content={renderTooltip} />
-          <Legend
-            verticalAlign="middle"
-            align="right"
-            layout="vertical"
-            formatter={(value: string) => (
-              <span className="text-sm text-gray-700">{value}</span>
-            )}
-          />
-        </PieChart>
-      </ResponsiveContainer>
-    </div>
+    <PieChart width={width} height={height}>
+      <Pie
+        data={dataWithPercentage}
+        cx="50%"
+        cy="50%"
+        innerRadius={60}
+        outerRadius={80}
+        paddingAngle={5}
+        dataKey="value"
+      >
+        {dataWithPercentage.map((entry, index) => (
+          <Cell key={`cell-${index}`} fill={entry.color} />
+        ))}
+      </Pie>
+      <Tooltip content={renderTooltip} />
+      <Legend
+        verticalAlign="middle"
+        align="right"
+        layout="vertical"
+        formatter={(value: string) => (
+          <span className="text-sm text-gray-700">{value}</span>
+        )}
+      />
+    </PieChart>
   );
 };
 

--- a/src/components/ui/Charts.tsx
+++ b/src/components/ui/Charts.tsx
@@ -6,7 +6,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  ResponsiveContainer,
   BarChart,
   Bar,
   LineChart,
@@ -16,6 +15,9 @@ import {
 interface ChartProps {
   type: 'area' | 'bar' | 'line';
   data: any[];
+  /** Width of the chart container. Defaults to 400 */
+  width?: number;
+  /** Height of the chart container. Defaults to 300 */
   height?: number;
   xKey: string;
   yKeys: {
@@ -29,6 +31,7 @@ interface ChartProps {
 const Charts: React.FC<ChartProps> = ({
   type,
   data,
+  width = 400,
   height = 300,
   xKey,
   yKeys,
@@ -55,9 +58,9 @@ const Charts: React.FC<ChartProps> = ({
 
   const renderChart = () => {
     const commonProps = {
-      width: '100%',
-      height: height,
-      data: data,
+      width,
+      height,
+      data,
       margin: { top: 10, right: 30, left: 0, bottom: 0 }
     };
 
@@ -169,13 +172,7 @@ const Charts: React.FC<ChartProps> = ({
     }
   };
 
-  return (
-    <div className="w-full" style={{ height }}>
-      <ResponsiveContainer>
-        {renderChart()}
-      </ResponsiveContainer>
-    </div>
-  );
+  return renderChart();
 };
 
 export default Charts;


### PR DESCRIPTION
## Summary
- add width/height props to `Charts` and `BudgetChart`
- render charts with explicit dimensions
- mount `<App />` in a sized container in tests

## Testing
- `npm test --silent -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688b4ff55ec4832588e968a6266dd96e