### PR TITLE
Implement onboarding analytics and a11y

### DIFF
--- a/src/__tests__/TaxOnboarding.a11y.test.tsx
+++ b/src/__tests__/TaxOnboarding.a11y.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import TaxOnboarding from '../pages/TaxOnboarding';
+
+vi.mock('../contexts/AuthContext', () => {
+  return { useAuthContext: () => ({ user: { id: 'test-user' }, company: null, loading: false }) };
+});
+
+describe('TaxOnboarding accessibility', () => {
+  it('associates SIREN label with its input', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <TaxOnboarding />
+      </MemoryRouter>
+    );
+    const label = screen.getByText('SIREN');
+    expect(label).toHaveAttribute('for', 'siren');
+    expect(container.querySelector('#siren')).not.toBeNull();
+  });
+});

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -394,6 +394,29 @@ export interface Database {
           updated_at?: string
         }
       }
+      analytics_events: {
+        Row: {
+          id: string
+          user_id: string | null
+          step_id: number | null
+          event: string | null
+          timestamp: string
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          step_id?: number | null
+          event?: string | null
+          timestamp?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          step_id?: number | null
+          event?: string | null
+          timestamp?: string
+        }
+      }
     }
   }
 }

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -1,0 +1,13 @@
+import { supabase } from '../supabase';
+
+export async function logOnboardingEvent(
+  event: 'stepStarted' | 'stepCompleted' | 'onboardingCompleted',
+  payload: { stepId: number; userId: string | null }
+) {
+  await supabase.from('analytics_events').insert({
+    user_id: payload.userId,
+    step_id: payload.stepId,
+    event,
+    timestamp: new Date().toISOString()
+  });
+}

--- a/supabase/migrations/20250524120000_add_analytics_events.sql
+++ b/supabase/migrations/20250524120000_add_analytics_events.sql
@@ -1,0 +1,14 @@
+-- Analytics events table for onboarding tracking
+CREATE TABLE IF NOT EXISTS analytics_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id),
+  step_id integer,
+  event text,
+  timestamp timestamptz DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE analytics_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own analytics" ON analytics_events
+  FOR ALL USING (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- add Supabase table `analytics_events` and TypeScript types
- create `logOnboardingEvent` helper
- instrument onboarding steps with analytics events and remove setTimeout delay
- fix form labels to use `htmlFor`/`id`
- add accessibility test for SIREN input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b69522f5483258add5c6d2b6011f3