### PR TITLE
Implement Modules & Expert recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Onboarding Express]
+- Added intelligent module and expert preselection with `ModulesExpertStep`.
+- New hook `useModuleRecommendations` and expert table.

--- a/src/__tests__/moduleMapping.test.ts
+++ b/src/__tests__/moduleMapping.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import mapping from '../config/module-mapping';
+
+describe('module mapping', () => {
+  it('returns modules for sector', () => {
+    expect(mapping['commerce']).toEqual(['e-invoice', 'inventory']);
+    expect(mapping['services']).toEqual(['project-tracking', 'time-billing']);
+    expect(mapping['industrie']).toEqual(['asset-management', 'production']);
+  });
+});

--- a/src/__tests__/useModuleRecommendations.test.tsx
+++ b/src/__tests__/useModuleRecommendations.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useModuleRecommendations } from '../lib/hooks/useModuleRecommendations';
+
+vi.mock('../lib/supabase', () => {
+  return {
+    supabase: {
+      from: () => ({
+        select: () => ({
+          contains: () => ({
+            gte: () => ({
+              order: () => ({
+                limit: async () => ({ data: [{ id: 'exp1', name: 'Expert', sectors: ['commerce'], rating: 4.6 }], error: null })
+              })
+            })
+          })
+        })
+      })
+    }
+  };
+});
+
+describe('useModuleRecommendations', () => {
+  it('returns modules and expert', async () => {
+    const { result } = renderHook(() =>
+      useModuleRecommendations({ sector: 'commerce', size: 'small' })
+    );
+
+    await waitFor(() => {
+      expect(result.current.expert).not.toBeNull();
+    });
+
+    expect(result.current.modules).toEqual(['e-invoice', 'inventory']);
+    expect(result.current.expert?.id).toBe('exp1');
+  });
+});

--- a/src/config/module-mapping.ts
+++ b/src/config/module-mapping.ts
@@ -1,0 +1,7 @@
+export const moduleMapping: Record<string, string[]> = {
+  commerce: ["e-invoice", "inventory"],
+  services: ["project-tracking", "time-billing"],
+  industrie: ["asset-management", "production"]
+};
+
+export default moduleMapping;

--- a/src/flows/onboarding/ModulesExpertStep.tsx
+++ b/src/flows/onboarding/ModulesExpertStep.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from 'react';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+import { useModuleRecommendations, CompanyData, Expert } from '../../lib/hooks/useModuleRecommendations';
+import { logOnboardingEvent } from '../../lib/hooks/useAnalytics';
+
+interface ModulesExpertStepProps {
+  companyData: CompanyData;
+  onComplete: (modules: string[], expert: Expert | null) => void;
+  onSkip: () => void;
+}
+
+const ModulesExpertStep: React.FC<ModulesExpertStepProps> = ({ companyData, onComplete, onSkip }) => {
+  if (import.meta.env.VITE_ONBOARDING_V2 !== 'true') return null;
+
+  const { modules: suggestedModules, expert } = useModuleRecommendations(companyData);
+  const [selectedModules, setSelectedModules] = useState<string[]>([]);
+  const [selectedExpertId, setSelectedExpertId] = useState<string>('');
+
+  useEffect(() => {
+    setSelectedModules(suggestedModules);
+  }, [suggestedModules]);
+
+  useEffect(() => {
+    if (expert) {
+      setSelectedExpertId(expert.id);
+    }
+  }, [expert]);
+
+  const toggleModule = (id: string) => {
+    setSelectedModules(prev =>
+      prev.includes(id) ? prev.filter(m => m !== id) : [...prev, id]
+    );
+  };
+
+  const handleFinish = async () => {
+    await logOnboardingEvent('modulesSuggested', {
+      stepId: 3,
+      userId: null,
+    });
+    await logOnboardingEvent('expertSuggested', {
+      stepId: 3,
+      userId: null,
+    });
+    onComplete(selectedModules, expert && expert.id === selectedExpertId ? expert : null);
+  };
+
+  const handleSkip = async () => {
+    await logOnboardingEvent('modulesSkipped', { stepId: 3, userId: null });
+    onSkip();
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card title="Modules recommandés">
+        <div className="space-y-3">
+          {suggestedModules.map(id => (
+            <label key={id} className="flex items-center focus-within:ring">
+              <input
+                type="checkbox"
+                checked={selectedModules.includes(id)}
+                onChange={() => toggleModule(id)}
+                className="form-checkbox text-primary rounded"
+              />
+              <span className="ml-2 text-sm text-gray-700">{id}</span>
+            </label>
+          ))}
+        </div>
+      </Card>
+
+      {expert && (
+        <Card title="Expert associé">
+          <label className="flex items-center focus-within:ring">
+            <input
+              type="radio"
+              name="expert"
+              checked={selectedExpertId === expert.id}
+              onChange={() => setSelectedExpertId(expert.id)}
+              className="form-radio text-primary"
+            />
+            <span className="ml-2 text-sm text-gray-700">{expert.name}</span>
+          </label>
+          <label className="flex items-center mt-2 focus-within:ring">
+            <input
+              type="radio"
+              name="expert"
+              value="generaliste"
+              checked={selectedExpertId === 'generaliste'}
+              onChange={() => setSelectedExpertId('generaliste')}
+              className="form-radio text-primary"
+            />
+            <span className="ml-2 text-sm text-gray-700">Généraliste</span>
+          </label>
+        </Card>
+      )}
+
+      <div className="flex justify-between">
+        <Button variant="secondary" onClick={handleSkip}>Je passe cette étape</Button>
+        <Button variant="primary" onClick={handleFinish}>Finaliser l'inscription</Button>
+      </div>
+    </div>
+  );
+};
+
+export default ModulesExpertStep;

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -417,6 +417,26 @@ export interface Database {
           timestamp?: string
         }
       }
+      ,experts: {
+        Row: {
+          id: string
+          name: string
+          sectors: string[]
+          rating: number
+        }
+        Insert: {
+          id?: string
+          name: string
+          sectors: string[]
+          rating: number
+        }
+        Update: {
+          id?: string
+          name?: string
+          sectors?: string[]
+          rating?: number
+        }
+      }
     }
   }
 }

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -1,7 +1,13 @@
 import { supabase } from '../supabase';
 
 export async function logOnboardingEvent(
-  event: 'stepStarted' | 'stepCompleted' | 'onboardingCompleted',
+  event:
+    | 'stepStarted'
+    | 'stepCompleted'
+    | 'onboardingCompleted'
+    | 'modulesSuggested'
+    | 'expertSuggested'
+    | 'modulesSkipped',
   payload: { stepId: number; userId: string | null }
 ) {
   await supabase.from('analytics_events').insert({

--- a/src/lib/hooks/useModuleRecommendations.ts
+++ b/src/lib/hooks/useModuleRecommendations.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabase';
+import type { Database } from '../database.types';
+import moduleMapping from '../../config/module-mapping';
+
+export interface CompanyData {
+  sector: string;
+  size: string;
+}
+
+export type Expert = Database['public']['Tables']['experts']['Row'];
+
+export function useModuleRecommendations(companyData: CompanyData) {
+  const [expert, setExpert] = useState<Expert | null>(null);
+
+  const modules = moduleMapping[companyData.sector] || [];
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchExpert() {
+      const { data, error } = await supabase
+        .from('experts')
+        .select('*')
+        .contains('sectors', [companyData.sector])
+        .gte('rating', 4.5)
+        .order('rating', { ascending: false })
+        .limit(1);
+
+      if (!cancelled) {
+        if (error) {
+          console.error('Error fetching experts', error);
+        }
+        if (data && data.length > 0) {
+          setExpert(data[0]);
+        } else {
+          const { data: generalist } = await supabase
+            .from('experts')
+            .select('*')
+            .eq('name', 'généraliste')
+            .limit(1);
+          setExpert(generalist && generalist.length > 0 ? generalist[0] : null);
+        }
+      }
+    }
+
+    fetchExpert();
+    return () => {
+      cancelled = true;
+    };
+  }, [companyData.sector]);
+
+  return { modules, expert };
+}

--- a/supabase/migrations/20250525130000_add_experts_table.sql
+++ b/supabase/migrations/20250525130000_add_experts_table.sql
@@ -1,0 +1,12 @@
+-- Table for onboarding expert matching
+CREATE TABLE IF NOT EXISTS experts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  sectors text[] NOT NULL,
+  rating numeric NOT NULL DEFAULT 0
+);
+
+ALTER TABLE experts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Experts are public" ON experts
+  FOR SELECT USING (true);


### PR DESCRIPTION
## Summary
- add module mapping config
- add ModulesExpertStep component
- add expert recommendation hook
- extend analytics event logging
- update database types and add experts table migration
- add tests for mapping and hook
- document change in changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b75208d408325966533e2a93aef1b