### PR TITLE
Add onboarding component tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,3 @@
 VITE_SUPABASE_URL=http://localhost
 VITE_SUPABASE_ANON_KEY=anon-key
+VITE_ONBOARDING_V2=true

--- a/src/__tests__/CompanyActivityStep.test.tsx
+++ b/src/__tests__/CompanyActivityStep.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import CompanyActivityStep from '../flows/onboarding/CompanyActivityStep';
+import { describe, it, expect, vi } from 'vitest';
+
+const sizes = [
+  { id: 'micro', label: 'Micro-entreprise', description: '', icon: <div /> },
+  { id: 'pme', label: 'PME', description: '', icon: <div /> }
+];
+
+const sectors = [
+  { id: 'retail', label: 'Retail' },
+  { id: 'services', label: 'Services' }
+];
+
+describe('<CompanyActivityStep />', () => {
+  it('updates company size on click', () => {
+    const setCompanySize = vi.fn();
+    render(
+      <CompanyActivityStep
+        companySize=""
+        setCompanySize={setCompanySize}
+        sector=""
+        setSector={vi.fn()}
+        legalName=""
+        setLegalName={vi.fn()}
+        siren=""
+        setSiren={vi.fn()}
+        address=""
+        setAddress={vi.fn()}
+        postalCode=""
+        setPostalCode={vi.fn()}
+        city=""
+        setCity={vi.fn()}
+        activityDesc=""
+        setActivityDesc={vi.fn()}
+        taxRegime="is"
+        setTaxRegime={vi.fn()}
+        onAutoFill={vi.fn()}
+        activitySectors={sectors}
+        companySizes={sizes}
+      />
+    );
+    fireEvent.click(screen.getAllByText('Micro-entreprise')[0]);
+    expect(setCompanySize).toHaveBeenCalledWith('micro');
+  });
+
+  it('triggers auto-fill', () => {
+    const onAutoFill = vi.fn();
+    render(
+      <CompanyActivityStep
+        companySize="micro"
+        setCompanySize={vi.fn()}
+        sector="retail"
+        setSector={vi.fn()}
+        legalName=""
+        setLegalName={vi.fn()}
+        siren="123"
+        setSiren={vi.fn()}
+        address=""
+        setAddress={vi.fn()}
+        postalCode=""
+        setPostalCode={vi.fn()}
+        city=""
+        setCity={vi.fn()}
+        activityDesc=""
+        setActivityDesc={vi.fn()}
+        taxRegime="is"
+        setTaxRegime={vi.fn()}
+        onAutoFill={onAutoFill}
+        activitySectors={sectors}
+        companySizes={sizes}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Auto-remplir/i }));
+    expect(onAutoFill).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/useAnalytics.test.ts
+++ b/src/__tests__/useAnalytics.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('logOnboardingEvent', () => {
+  it('inserts event in supabase', async () => {
+    const insert = vi.fn().mockResolvedValue({});
+    const from = vi.fn(() => ({ insert }));
+    vi.doMock('../lib/supabase', () => ({ supabase: { from } }));
+
+    const { logOnboardingEvent } = await import('../lib/hooks/useAnalytics');
+    await logOnboardingEvent('stepStarted', { stepId: 1, userId: '1' });
+    expect(from).toHaveBeenCalledWith('analytics_events');
+    expect(insert).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- cover CompanyActivityStep interactions
- unit test analytics logging
- enable onboarding flag in test env

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b83360b6483259cb4847a639e2940