### PR TITLE
feat(onboarding): add QR code document upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@
 - Added intelligent module and expert preselection with `ModulesExpertStep`.
 - New hook `useModuleRecommendations` and expert table.
 - Introduced premium completion screen with `OnboardingSuccess` and micro feedback.
+
+## [Onboarding QR]
+- Added `QRScanStep` component generating time-limited QR codes for document upload.
+- Introduced `onboardingQR` feature flag and Supabase `ocr_sessions` tracking.

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:5173',
+    supportFile: false
+  }
+});

--- a/cypress/e2e/onboardingQR.cy.ts
+++ b/cypress/e2e/onboardingQR.cy.ts
@@ -1,0 +1,13 @@
+describe('Onboarding QR', () => {
+  it('displays QR code and allows regeneration', () => {
+    cy.visit('/onboarding/start');
+    cy.get('img[alt="QR Code"]').should('be.visible');
+    cy.contains('Ce QR code expire').should('be.visible');
+    cy.contains('Régénérer').should('not.exist');
+    cy.clock();
+    cy.tick(10 * 60 * 1000);
+    cy.contains('QR code expiré').should('be.visible');
+    cy.contains('Régénérer').click();
+    cy.get('img[alt="QR Code"]').should('be.visible');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import SalaryManagement from './pages/SalaryManagement';
 import TaxOnboarding from './pages/TaxOnboarding';
 import TaxOnboardingV2 from './pages/TaxOnboardingV2';
 import OnboardingSuccess from './pages/OnboardingSuccess';
+import OnboardingStart from './pages/OnboardingStart';
 import './styles/globals.css';
 
 const App: React.FC = () => (
@@ -59,6 +60,7 @@ const App: React.FC = () => (
               element={import.meta.env.VITE_ONBOARDING_V2 === 'true' ? <TaxOnboardingV2 /> : <TaxOnboarding />}
             />
             <Route path="/onboarding/success" element={<OnboardingSuccess />} />
+            <Route path="/onboarding/start" element={<OnboardingStart />} />
           </Routes>
         </AuthProvider>
       </ToastProvider>

--- a/src/__tests__/QRScanStep.test.tsx
+++ b/src/__tests__/QRScanStep.test.tsx
@@ -1,0 +1,24 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import QRScanStep from '../components/onboarding/QRScanStep';
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuthContext: () => ({ user: { id: 'user-1' } })
+}));
+
+const insert = vi.fn();
+vi.mock('../lib/supabase', () => ({
+  supabase: { from: () => ({ insert }) }
+}));
+
+describe('QRScanStep', () => {
+  it('stores session with 10 minute expiration', async () => {
+    const { unmount } = render(<QRScanStep />);
+    await waitFor(() => expect(insert).toHaveBeenCalled());
+    const payload = insert.mock.calls[0][0];
+    const created = new Date(payload.created_at).getTime();
+    const expires = new Date(payload.expires_at).getTime();
+    expect(expires - created).toBe(10 * 60 * 1000);
+    unmount();
+  });
+});

--- a/src/components/onboarding/QRScanStep.tsx
+++ b/src/components/onboarding/QRScanStep.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import Button from '../ui/Button';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { supabase } from '../../lib/supabase';
+import { Buffer } from 'buffer';
+
+const QR_DURATION = 10 * 60 * 1000; // 10 minutes
+const QR_API = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=';
+
+function formatTime(ms: number) {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(total / 60).toString().padStart(2, '0');
+  const seconds = (total % 60).toString().padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+const QRScanStep: React.FC = () => {
+  const { user } = useAuthContext();
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<number>(0);
+  const [timeLeft, setTimeLeft] = useState<number>(QR_DURATION);
+
+  const generateSession = useCallback(async () => {
+    const id = crypto.randomUUID();
+    const now = Date.now();
+    const exp = now + QR_DURATION;
+    setSessionId(id);
+    setExpiresAt(exp);
+    setTimeLeft(QR_DURATION);
+    const createdAt = new Date(now).toISOString();
+    const expiresAtStr = new Date(exp).toISOString();
+    await supabase.from('ocr_sessions').insert({
+      session_id: id,
+      user_id: user?.id ?? '',
+      created_at: createdAt,
+      expires_at: expiresAtStr
+    });
+  }, [user]);
+
+  useEffect(() => {
+    generateSession();
+  }, [generateSession]);
+
+  useEffect(() => {
+    if (!expiresAt) return;
+    const interval = setInterval(() => {
+      setTimeLeft(expiresAt - Date.now());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [expiresAt]);
+
+  if (!sessionId) return null;
+  const base = typeof window !== 'undefined' && window.btoa ? window.btoa(sessionId) : Buffer.from(sessionId).toString('base64');
+  const encoded = base.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const scanUrl = `https://short.url/${encoded}`;
+  const qrSrc = `${QR_API}${encodeURIComponent(scanUrl)}`;
+  const expired = timeLeft <= 0;
+
+  return (
+    <div className="text-center">
+      {!expired && (
+        <>
+          <img src={qrSrc} alt="QR Code" className="mx-auto" />
+          <p className="mt-4 text-sm text-gray-600">
+            Ce QR code expire dans {formatTime(timeLeft)}
+          </p>
+        </>
+      )}
+      {expired && (
+        <>
+          <p className="text-sm text-red-600 mb-2">QR code expiré</p>
+          <Button variant="primary" onClick={generateSession}>
+            Régénérer
+          </Button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default QRScanStep;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_SUPABASE_ANON_KEY: string
   readonly VITE_SIRENE_API_TOKEN: string
   readonly VITE_ONBOARDING_V2: string
+  readonly VITE_ONBOARDING_QR: string
 }
 
 interface ImportMeta {

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -440,6 +440,26 @@ export interface Database {
           updated_at?: string | null
         }
       }
+      ,ocr_sessions: {
+        Row: {
+          session_id: string
+          user_id: string
+          created_at: string
+          expires_at: string
+        }
+        Insert: {
+          session_id: string
+          user_id: string
+          created_at?: string
+          expires_at: string
+        }
+        Update: {
+          session_id?: string
+          user_id?: string
+          created_at?: string
+          expires_at?: string
+        }
+      }
       ,experts: {
         Row: {
           id: string

--- a/src/pages/OnboardingStart.tsx
+++ b/src/pages/OnboardingStart.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import QRScanStep from '../components/onboarding/QRScanStep';
+import { useNavigate } from 'react-router-dom';
+
+const OnboardingStart: React.FC = () => {
+  const navigate = useNavigate();
+  const showQR = import.meta.env.VITE_ONBOARDING_QR === 'true';
+
+  return (
+    <div className="flex justify-center mt-10">
+      <Card className="text-center max-w-md">
+        {showQR && (
+          <>
+            <p className="mb-4">
+              Scannez ce QR code avec votre mobile pour envoyer automatiquement vos documents
+            </p>
+            <QRScanStep />
+          </>
+        )}
+        <div className="mt-4">
+          <Button variant="secondary" onClick={() => navigate('/documents')}>
+            Télécharger manuellement mes documents
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default OnboardingStart;


### PR DESCRIPTION
## Summary
- add QRScanStep component with timed QR code generation and session tracking in Supabase
- gate QR step behind onboardingQR flag and add start page route
- document feature in changelog

## Testing
- `npm test -- --run`
- `npx vitest run src/__tests__/QRScanStep.test.tsx` *(hangs, manually terminated)*
- `npx cypress run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cypress)*

------
https://chatgpt.com/codex/tasks/task_e_6890488d6e648325892a9cbd5d86900d