### PR TITLE
feat: add OCR validation drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Added OCR parsing pipeline with `/api/ocr/parse` endpoint and realtime updates.
 - New `useOcrUpdates` hook pre-fills company form after mobile upload.
 - Created `ocr-service` microservice and cleanup script for temporary storage.
+- Implemented OCR autofill with validation drawer and mismatch detection.

--- a/src/__tests__/CompanyActivityStep.test.tsx
+++ b/src/__tests__/CompanyActivityStep.test.tsx
@@ -3,6 +3,12 @@ import React from 'react';
 import CompanyActivityStep from '../flows/onboarding/CompanyActivityStep';
 import { describe, it, expect, vi } from 'vitest';
 
+vi.mock('../lib/hooks/useOcrUpdates', () => ({
+  useOcrUpdates: () => ({
+    data: { name: 'ACME', siren: '123456789', address: '1 rue', sector: 'retail' }
+  })
+}));
+
 const sizes = [
   { id: 'micro', label: 'Micro-entreprise', description: '', icon: <div /> },
   { id: 'pme', label: 'PME', description: '', icon: <div /> }
@@ -39,6 +45,8 @@ describe('<CompanyActivityStep />', () => {
         onAutoFill={vi.fn()}
         activitySectors={sectors}
         companySizes={sizes}
+        sessionId={null}
+        onAllConfirmedChange={vi.fn()}
       />
     );
     fireEvent.click(screen.getAllByText('Micro-entreprise')[0]);
@@ -70,9 +78,49 @@ describe('<CompanyActivityStep />', () => {
         onAutoFill={onAutoFill}
         activitySectors={sectors}
         companySizes={sizes}
+        sessionId={null}
+        onAllConfirmedChange={vi.fn()}
       />
     );
     fireEvent.click(screen.getByRole('button', { name: /Auto-remplir/i }));
     expect(onAutoFill).toHaveBeenCalled();
+  });
+
+  it('injects OCR data into fields', () => {
+    const setLegalName = vi.fn();
+    const setSiren = vi.fn();
+    const setAddress = vi.fn();
+    const setSector = vi.fn();
+    render(
+      <CompanyActivityStep
+        companySize="micro"
+        setCompanySize={vi.fn()}
+        sector=""
+        setSector={setSector}
+        legalName=""
+        setLegalName={setLegalName}
+        siren=""
+        setSiren={setSiren}
+        address=""
+        setAddress={setAddress}
+        postalCode=""
+        setPostalCode={vi.fn()}
+        city=""
+        setCity={vi.fn()}
+        activityDesc=""
+        setActivityDesc={vi.fn()}
+        taxRegime="is"
+        setTaxRegime={vi.fn()}
+        onAutoFill={vi.fn()}
+        activitySectors={sectors}
+        companySizes={sizes}
+        sessionId="abc"
+        onAllConfirmedChange={vi.fn()}
+      />
+    );
+    expect(setLegalName).toHaveBeenCalledWith('ACME');
+    expect(setSiren).toHaveBeenCalledWith('123456789');
+    expect(setAddress).toHaveBeenCalledWith('1 rue');
+    expect(setSector).toHaveBeenCalledWith('retail');
   });
 });

--- a/src/__tests__/OcrValidationDrawer.test.tsx
+++ b/src/__tests__/OcrValidationDrawer.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import OcrValidationDrawer, { ValidationField } from '../flows/onboarding/OcrValidationDrawer';
+
+describe('OcrValidationDrawer', () => {
+  it('calls onEdit when clicking Modifier', () => {
+    const fields: ValidationField[] = [
+      { key: 'siren', label: 'SIREN', value: '123', confirmed: true }
+    ];
+    const onEdit = vi.fn();
+    render(
+      <OcrValidationDrawer fields={fields} onConfirm={vi.fn()} onEdit={onEdit} />
+    );
+    fireEvent.click(screen.getByText('Modifier'));
+    expect(onEdit).toHaveBeenCalledWith('siren');
+  });
+});

--- a/src/__tests__/sirene.test.ts
+++ b/src/__tests__/sirene.test.ts
@@ -8,7 +8,8 @@ describe('fetchSirene', () => {
         unite_legale: { denomination: 'Test SA' },
         geo_adresse: '1 rue de la Paix',
         code_postal: '75000',
-        libelle_commune: 'Paris'
+        libelle_commune: 'Paris',
+        siren: '123456789'
       }
     };
 
@@ -22,7 +23,8 @@ describe('fetchSirene', () => {
       legalName: 'Test SA',
       address: '1 rue de la Paix',
       postalCode: '75000',
-      city: 'Paris'
+      city: 'Paris',
+      siren: '123456789'
     });
   });
 });

--- a/src/flows/onboarding/OcrValidationDrawer.tsx
+++ b/src/flows/onboarding/OcrValidationDrawer.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Button from '../../components/ui/Button';
+
+export interface ValidationField {
+  key: string;
+  label: string;
+  value: string;
+  confirmed: boolean;
+}
+
+interface Props {
+  fields: ValidationField[];
+  onConfirm: (key: string) => void;
+  onEdit: (key: string) => void;
+}
+
+const OcrValidationDrawer: React.FC<Props> = ({ fields, onConfirm, onEdit }) => {
+  if (fields.length === 0) return null;
+  return (
+    <div className="fixed right-0 top-0 h-full w-72 bg-white shadow-lg p-4 overflow-y-auto z-50">
+      <h3 className="text-lg font-medium mb-4">Validation rapide</h3>
+      <ul className="space-y-4">
+        {fields.map((f) => (
+          <li key={f.key} className="flex items-start justify-between">
+            <div className="flex-1 mr-2">
+              <p className="text-sm font-medium text-gray-700">{f.label}</p>
+              <p className="text-sm text-gray-500 truncate" title={f.value}>{f.value}</p>
+            </div>
+            <div className="flex flex-col items-end space-y-1">
+              <span className="text-xl" aria-label={f.confirmed ? 'Confirmé' : 'À vérifier'}>
+                {f.confirmed ? '✅' : '⚠️'}
+              </span>
+              {f.confirmed ? (
+                <Button size="sm" variant="secondary" onClick={() => onEdit(f.key)}>
+                  Modifier
+                </Button>
+              ) : (
+                <Button size="sm" variant="primary" onClick={() => onConfirm(f.key)}>
+                  Confirmer
+                </Button>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default OcrValidationDrawer;

--- a/src/lib/api/sirene.ts
+++ b/src/lib/api/sirene.ts
@@ -3,6 +3,7 @@ export interface SireneData {
   address: string;
   postalCode: string;
   city: string;
+  siren: string;
 }
 
 export async function fetchSirene(siren: string): Promise<SireneData> {
@@ -18,6 +19,7 @@ export async function fetchSirene(siren: string): Promise<SireneData> {
     legalName: etab?.unite_legale?.denomination || '',
     address: etab?.geo_adresse || '',
     postalCode: etab?.code_postal || '',
-    city: etab?.libelle_commune || ''
+    city: etab?.libelle_commune || '',
+    siren: etab?.siren || ''
   };
 }

--- a/src/pages/TaxOnboardingV2.tsx
+++ b/src/pages/TaxOnboardingV2.tsx
@@ -9,7 +9,6 @@ import CompanyActivityStep from '../flows/onboarding/CompanyActivityStep';
 import Modal from '../components/ui/Modal';
 import { supabase } from '../lib/supabase';
 import { fetchSirene } from '../lib/api/sirene';
-import { useOcrUpdates } from '../lib/hooks/useOcrUpdates';
 import { 
   FileCheck, 
   Building2, 
@@ -145,16 +144,7 @@ const TaxOnboarding: React.FC = () => {
     qrEnabled && typeof window !== 'undefined'
       ? localStorage.getItem('ocrSessionId')
       : null;
-  const { data: ocrData, highlight } = useOcrUpdates(sessionId);
-
-  useEffect(() => {
-    if (ocrData) {
-      setLegalName(ocrData.name);
-      setSiren(ocrData.siren);
-      setAddress(ocrData.address);
-      setSector(ocrData.sector);
-    }
-  }, [ocrData]);
+  const [ocrConfirmed, setOcrConfirmed] = useState(false);
   
   // Initialize with recommended modules
   useEffect(() => {
@@ -338,7 +328,7 @@ const TaxOnboarding: React.FC = () => {
   const isStepValid = () => {
     switch (currentStep) {
       case 1:
-        return companySize !== '' && sector !== '';
+        return companySize !== '' && sector !== '' && (!qrEnabled || ocrConfirmed);
       case 2:
         return selectedModules.length > 0;
       case 3:
@@ -391,7 +381,8 @@ const TaxOnboarding: React.FC = () => {
             activitySectors={activitySectors}
             companySizes={companySizes}
             onAutoFill={handleAutoFill}
-            highlight={highlight}
+            sessionId={sessionId}
+            onAllConfirmedChange={setOcrConfirmed}
           />
           <div className="flex justify-end mt-6">
             <Button


### PR DESCRIPTION
## Summary
- add drawer to confirm OCR autofill with per-field highlights
- track mismatched SIREN and corrections
- block progression until all OCR fields confirmed

## Testing
- `npm test -- --run`
- `npx cypress run --spec cypress/e2e/onboardingQR.cy.ts` *(fails: missing Xvfb)*


------
https://chatgpt.com/codex/tasks/task_e_6890669903548325a586c7276638c227