### PR TITLE
feat: add QR onboarding KPI dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,6 @@
 - Created `ocr-service` microservice and cleanup script for temporary storage.
 - Implemented OCR autofill with validation drawer and mismatch detection.
 - Added runtime `onboardingQR` feature flag with admin dashboard and SWR hook.
+
+## [Analytics]
+- Added real-time QR onboarding KPI dashboard with `/admin/kpi-qr` page and `get_qr_kpi` RPC.

--- a/cypress/e2e/kpiQr.cy.ts
+++ b/cypress/e2e/kpiQr.cy.ts
@@ -1,0 +1,27 @@
+describe('QR KPI dashboard', () => {
+  it('shows metrics for admin', () => {
+    cy.intercept('POST', '**/rest/v1/rpc/get_qr_kpi', {
+      statusCode: 200,
+      body: [{ ttfv_ms: 1000, ttfv_sparkline: [1000, 2000], drop_off: 0.05, adoption_qr: 30, adoption_classic: 70, parsing_success: 0.9 }]
+    }).as('kpi');
+
+    cy.visit('/admin/kpi-qr', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('sb-localhost-auth-token', JSON.stringify({
+          currentSession: {
+            access_token: 'token',
+            refresh_token: 'refresh',
+            user: { id: '1', user_metadata: { role: 'admin' } }
+          },
+          expiresAt: Math.floor(Date.now() / 1000) + 3600
+        }));
+      }
+    });
+
+    cy.wait('@kpi');
+    cy.contains('TTFV').should('be.visible');
+    cy.contains('Drop-off').should('be.visible');
+    cy.contains('Adoption').should('be.visible');
+    cy.contains('Parsing success').should('be.visible');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import OnboardingSuccess from './pages/OnboardingSuccess';
 import OnboardingStart from './pages/OnboardingStart';
 import QrUploadPage from './pages/QrUploadPage';
 import FeatureFlagsPage from './pages/admin/FeatureFlagsPage';
+import KpiQrPage from './pages/admin/kpi-qr';
 import { useFeatureFlag } from './lib/hooks/useFeatureFlag';
 import { Navigate } from 'react-router-dom';
 import './styles/globals.css';
@@ -74,6 +75,7 @@ const App: React.FC = () => (
             <Route path="/onboarding/start" element={<OnboardingStart />} />
             <Route path="/qr-upload/:sessionToken" element={<QrUploadRoute />} />
             <Route path="/admin/feature-flags" element={<Layout><FeatureFlagsPage /></Layout>} />
+            <Route path="/admin/kpi-qr" element={<Layout><KpiQrPage /></Layout>} />
           </Routes>
         </AuthProvider>
       </ToastProvider>

--- a/src/__tests__/qrKpi.test.ts
+++ b/src/__tests__/qrKpi.test.ts
@@ -1,0 +1,13 @@
+import { vi } from 'vitest';
+import { supabase } from '../lib/supabase';
+import { fetchQrKpi } from '../lib/api/qrKpi';
+
+describe('fetchQrKpi', () => {
+  it('calls rpc and returns data', async () => {
+    const mock = [{ ttfv_ms: 1000, ttfv_sparkline: [500], drop_off: 0.1, adoption_qr: 10, adoption_classic: 20, parsing_success: 0.9 }];
+    const rpc = vi.spyOn(supabase, 'rpc').mockResolvedValue({ data: mock } as any);
+    const result = await fetchQrKpi();
+    expect(rpc).toHaveBeenCalledWith('get_qr_kpi');
+    expect(result).toEqual(mock[0]);
+  });
+});

--- a/src/lib/api/qrKpi.ts
+++ b/src/lib/api/qrKpi.ts
@@ -1,0 +1,16 @@
+import { supabase } from '../supabase';
+
+export interface QrKpiResponse {
+  ttfv_ms: number;
+  ttfv_sparkline: number[];
+  drop_off: number;
+  adoption_qr: number;
+  adoption_classic: number;
+  parsing_success: number;
+}
+
+export async function fetchQrKpi() {
+  const { data, error } = await supabase.rpc('get_qr_kpi');
+  if (error) throw error;
+  return (data as QrKpiResponse[])[0];
+}

--- a/src/lib/useSWR.ts
+++ b/src/lib/useSWR.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+interface Options {
+  refreshInterval?: number;
+}
+
+export default function useSWR<T>(key: string, fetcher: () => Promise<T>, options?: Options) {
+  const [data, setData] = useState<T | undefined>();
+  const [error, setError] = useState<any>(null);
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      try {
+        const result = await fetcher();
+        if (active) setData(result);
+      } catch (err) {
+        if (active) setError(err);
+      }
+    };
+    load();
+    const interval = options?.refreshInterval
+      ? setInterval(load, options.refreshInterval)
+      : null;
+    return () => {
+      active = false;
+      if (interval) clearInterval(interval);
+    };
+  }, [key]);
+
+  return { data, error } as const;
+}

--- a/src/pages/admin/kpi-qr.tsx
+++ b/src/pages/admin/kpi-qr.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import useSWR from '../../lib/useSWR';
+import { fetchQrKpi, QrKpiResponse } from '../../lib/api/qrKpi';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { Card } from '../../components/ui/Card';
+import Charts from '../../components/ui/Charts';
+import { ArrowDown, ArrowUp } from 'lucide-react';
+
+const KpiQrPage: React.FC = () => {
+  const { user } = useAuthContext();
+  const role = (user?.user_metadata as any)?.role;
+  if (role !== 'admin' && role !== 'product_owner') {
+    return <p className="p-4">Accès refusé</p>;
+  }
+
+  const { data } = useSWR<QrKpiResponse>('qr-kpi', fetchQrKpi, { refreshInterval: 30000 });
+
+  if (!data) return <p className="p-4">Chargement...</p>;
+
+  const sparkData = data.ttfv_sparkline.map((v, i) => ({ i, v: v / 1000 }));
+  const adoptionData = [
+    { type: 'QR', value: data.adoption_qr },
+    { type: 'Classique', value: data.adoption_classic }
+  ];
+  const dropTrend = data.drop_off <= 0.1 ? 'down' : 'up';
+  const DropIcon = dropTrend === 'down' ? ArrowDown : ArrowUp;
+
+  return (
+    <div className="p-4 grid gap-4 md:grid-cols-2">
+      <Card className="p-4">
+        <h2 className="text-sm text-gray-500">TTFV</h2>
+        <p className="text-2xl font-bold">{Math.round(data.ttfv_ms / 1000)}s</p>
+        <Charts type="line" data={sparkData} xKey="i" yKeys={[{ key: 'v', name: 'TTFV', color: '#2563eb' }]} width={150} height={60} />
+      </Card>
+      <Card className="p-4 flex flex-col">
+        <h2 className="text-sm text-gray-500">Drop-off</h2>
+        <div className="flex items-center mt-2">
+          <p className="text-2xl font-bold">{Math.round(data.drop_off * 100)}%</p>
+          <DropIcon className={dropTrend === 'down' ? 'text-green-600 ml-2' : 'text-red-600 ml-2'} />
+        </div>
+      </Card>
+      <Card className="p-4">
+        <h2 className="text-sm text-gray-500">Adoption</h2>
+        <Charts type="bar" data={adoptionData} xKey="type" yKeys={[{ key: 'value', name: 'Utilisateurs', color: '#7c3aed' }]} width={200} height={120} />
+      </Card>
+      <Card className="p-4">
+        <h2 className="text-sm text-gray-500">Parsing success</h2>
+        <div className="mt-2 w-full bg-gray-200 rounded h-4">
+          <div className="bg-green-500 h-4 rounded" style={{ width: `${Math.round(data.parsing_success * 100)}%` }}></div>
+        </div>
+        <p className="mt-2 text-sm font-medium">{Math.round(data.parsing_success * 100)}%</p>
+      </Card>
+    </div>
+  );
+};
+
+export default KpiQrPage;

--- a/supabase/migrations/20250701120000_get_qr_kpi_rpc.sql
+++ b/supabase/migrations/20250701120000_get_qr_kpi_rpc.sql
@@ -1,0 +1,42 @@
+-- RPC to aggregate QR onboarding KPIs
+create or replace function get_qr_kpi()
+returns table (
+  ttfv_ms numeric,
+  ttfv_sparkline numeric[],
+  drop_off numeric,
+  adoption_qr integer,
+  adoption_classic integer,
+  parsing_success numeric
+)
+language sql
+stable
+as $$
+with ttfv as (
+  select
+    coalesce(avg(duration_ms),0) as avg_ms,
+    coalesce(array_agg(duration_ms order by timestamp)
+             filter (where timestamp > now() - interval '24 hour'),
+             array[]::numeric[]) as sparkline
+  from analytics_events
+  where event = 'qrUploadCompleted'
+), counts as (
+  select
+    count(*) filter (where event = 'qrUploadStarted') as started,
+    count(*) filter (where event = 'onboardingCompleted') as completed,
+    count(*) filter (where event = 'onboardingQR') as adoption_qr,
+    count(*) filter (where event = 'onboardingClassic') as adoption_classic,
+    count(*) filter (where event = 'ocrParseSucceeded') as parse_ok,
+    count(*) filter (where event in ('ocrParseSucceeded','ocrParseFailed')) as parse_total
+  from analytics_events
+)
+select
+  ttfv.avg_ms as ttfv_ms,
+  ttfv.sparkline as ttfv_sparkline,
+  case when counts.started = 0 then 0
+       else 1 - counts.completed::numeric / counts.started end as drop_off,
+  counts.adoption_qr,
+  counts.adoption_classic,
+  case when counts.parse_total = 0 then 0
+       else counts.parse_ok::numeric / counts.parse_total end as parsing_success
+from ttfv, counts;
+$$;


### PR DESCRIPTION
## Summary
- add `get_qr_kpi` RPC aggregating QR onboarding analytics
- create admin dashboard `/admin/kpi-qr` with auto-refreshing KPI cards
- document new dashboard in changelog

## Testing
- `npm test -- --run`
- `npx vitest run src/__tests__/qrKpi.test.ts`
- `npx cypress run` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68907805e6c483258436c42b98579c4f