### PR TITLE
[Upsell P2] Suggested modules widget

### DIFF
--- a/cypress/e2e/suggestedModulesWidget.cy.ts
+++ b/cypress/e2e/suggestedModulesWidget.cy.ts
@@ -1,0 +1,32 @@
+describe('SuggestedModulesWidget', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/api/reco/modules*', {
+      body: [
+        { moduleId: 'e-invoice' },
+        { moduleId: 'inventory' },
+        { moduleId: 'project-tracking' }
+      ]
+    });
+    cy.intercept('GET', '**/rest/v1/feature_flags*', {
+      body: [{ is_enabled: true }]
+    });
+  });
+
+  it('desktop: widget présent et CTA ouvre modal', () => {
+    cy.viewport(1280, 720);
+    cy.visit('/');
+    cy.contains('Essayer').first().click();
+    cy.on('window:alert', (txt) => {
+      expect(txt).to.contain('Try & Buy');
+    });
+  });
+
+  it('mobile: widget positionné et CTA fonctionne', () => {
+    cy.viewport(375, 667);
+    cy.visit('/');
+    cy.contains('Essayer').first().click();
+    cy.on('window:alert', (txt) => {
+      expect(txt).to.contain('Try & Buy');
+    });
+  });
+});

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -7,7 +7,10 @@ import { ThemeProvider } from '../contexts/ThemeContext';
 import ReactImport from 'react';
 
 vi.mock('../contexts/AuthContext', () => {
-  return { AuthProvider: ({ children }: { children: ReactImport.ReactNode }) => <>{children}</> };
+  return {
+    AuthProvider: ({ children }: { children: ReactImport.ReactNode }) => <>{children}</>,
+    useAuthContext: () => ({ user: null, company: null, loading: false })
+  };
 });
 
 describe('<App />', () => {

--- a/src/__tests__/SuggestedModulesWidget.test.tsx
+++ b/src/__tests__/SuggestedModulesWidget.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SuggestedModulesWidget from '../components/widgets/SuggestedModulesWidget';
+
+vi.mock('../lib/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: () => ({ enabled: true, loading: false, error: null })
+}));
+
+vi.mock('../lib/hooks/useAnalytics', () => ({
+  logRecoEvent: vi.fn()
+}));
+
+describe('SuggestedModulesWidget', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve([
+            { moduleId: 'e-invoice' },
+            { moduleId: 'inventory' },
+            { moduleId: 'project-tracking' }
+          ])
+      }) as any
+    ));
+  });
+
+  it('affiche les cartes modules', async () => {
+    render(<SuggestedModulesWidget accountId="1" />);
+    await waitFor(() => {
+      expect(screen.getByText('Facturation')).toBeInTheDocument();
+    });
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+});

--- a/src/components/widgets/SuggestedModulesWidget.mdx
+++ b/src/components/widgets/SuggestedModulesWidget.mdx
@@ -1,0 +1,9 @@
+import SuggestedModulesWidget from './SuggestedModulesWidget';
+
+# SuggestedModulesWidget
+
+Widget affichant les modules recommandés via l'API `/api/reco/modules`.
+
+```
+<SuggestedModulesWidget accountId="123" />
+```

--- a/src/components/widgets/SuggestedModulesWidget.tsx
+++ b/src/components/widgets/SuggestedModulesWidget.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect } from 'react';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+import { useFeatureFlag } from '../../lib/hooks/useFeatureFlag';
+import { useSuggestedModules } from '../../lib/hooks/useSuggestedModules';
+import suggestedModules from '../../config/suggested-modules';
+import { logRecoEvent } from '../../lib/hooks/useAnalytics';
+
+interface Props {
+  accountId: string;
+}
+
+const SuggestedModulesWidget: React.FC<Props> = ({ accountId }) => {
+  const { enabled } = useFeatureFlag('upsellRecoV1');
+  const { modules, isLoading } = useSuggestedModules(accountId);
+
+  useEffect(() => {
+    if (modules && modules.length > 0) {
+      const position = window.innerWidth < 768 ? 'mobile' : 'desktop';
+      void logRecoEvent('recoWidgetViewed', {
+        moduleIds: modules.map((m) => m.moduleId),
+        position
+      });
+    }
+  }, [modules]);
+
+  if (!enabled) return null;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-20 bg-gray-100 rounded animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  const items = modules?.map((m) => suggestedModules[m.moduleId]).filter(Boolean) || [];
+
+  if (items.length === 0) {
+    return (
+      <Card className="p-4">
+        <p className="text-sm text-gray-600">Aucun module recommandé pour l'instant</p>
+        <a href="/store" className="text-primary text-sm underline">
+          Découvrir le store
+        </a>
+      </Card>
+    );
+  }
+
+  return (
+    <div role="list" className="space-y-4">
+      {items.map((item) => {
+        const Icon = item.icon;
+        return (
+          <div
+            key={item.id}
+            role="listitem"
+            tabIndex={0}
+            aria-label={`${item.name} - ${item.benefit}`}
+            className="focus:outline-none focus:ring-2 focus:ring-primary rounded"
+          >
+            <Card className="p-4 flex items-center justify-between">
+              <div className="flex items-center space-x-3">
+                <Icon size={24} className="text-primary" />
+                <div>
+                  <h4 className="font-medium text-gray-900">{item.name}</h4>
+                  <p className="text-sm text-gray-500">
+                    {item.benefit.length > 60 ? `${item.benefit.slice(0, 57)}...` : item.benefit}
+                  </p>
+                  <span className="inline-block mt-1 px-2 py-0.5 text-xs bg-primary text-white rounded">
+                    {/** i18n key: upsell.freeTrialBadge */}
+                    Essai gratuit 7 j
+                  </span>
+                </div>
+              </div>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  const position = window.innerWidth < 768 ? 'mobile' : 'desktop';
+                  void logRecoEvent('recoWidgetClicked', {
+                    moduleId: item.id,
+                    position
+                  });
+                  window.alert('Try & Buy');
+                }}
+                title={item.price}
+              >
+                Essayer
+              </Button>
+            </Card>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SuggestedModulesWidget;

--- a/src/config/suggested-modules.tsx
+++ b/src/config/suggested-modules.tsx
@@ -1,0 +1,35 @@
+import { LucideIcon, FileText, Box, ClipboardList } from 'lucide-react';
+
+export interface ModuleDetails {
+  id: string;
+  name: string;
+  benefit: string;
+  price: string;
+  icon: LucideIcon;
+}
+
+export const suggestedModules: Record<string, ModuleDetails> = {
+  'e-invoice': {
+    id: 'e-invoice',
+    name: 'Facturation',
+    benefit: 'Automatisez vos factures',
+    price: '15€/mois',
+    icon: FileText
+  },
+  inventory: {
+    id: 'inventory',
+    name: 'Inventaire',
+    benefit: 'Suivez vos stocks',
+    price: '25€/mois',
+    icon: Box
+  },
+  'project-tracking': {
+    id: 'project-tracking',
+    name: 'Projets',
+    benefit: 'Gérez vos projets efficacement',
+    price: '19€/mois',
+    icon: ClipboardList
+  }
+};
+
+export default suggestedModules;

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -24,7 +24,12 @@ export async function logOnboardingEvent(
 }
 
 export async function logRecoEvent(
-  event: 'recoServed' | 'recoClicked' | 'recoActivated',
+  event:
+    | 'recoServed'
+    | 'recoClicked'
+    | 'recoActivated'
+    | 'recoWidgetViewed'
+    | 'recoWidgetClicked',
   payload: { userId?: string | null; [key: string]: any }
 ) {
   const { userId, ...details } = payload;

--- a/src/lib/hooks/useSuggestedModules.ts
+++ b/src/lib/hooks/useSuggestedModules.ts
@@ -1,0 +1,21 @@
+import useSWR from '../useSWR';
+
+interface ApiModule {
+  moduleId: string;
+}
+
+export function useSuggestedModules(accountId: string) {
+  const token = btoa(JSON.stringify({ role: 'user' }));
+  const fetcher = () =>
+    fetch(`/api/reco/modules?accountId=${accountId}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    }).then((r) => r.json() as Promise<ApiModule[]>);
+
+  const { data, error } = useSWR(`/api/reco/modules?accountId=${accountId}`, fetcher);
+
+  return {
+    modules: data,
+    isLoading: !data && !error,
+    error
+  } as const;
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,6 +5,8 @@ import Button from '../components/ui/Button';
 import Charts from '../components/ui/Charts';
 import MaxAssistant from '../components/ui/MaxAssistant';
 import { useToast } from '../contexts/ToastContext';
+import SuggestedModulesWidget from '../components/widgets/SuggestedModulesWidget';
+import { useAuthContext } from '../contexts/AuthContext';
 import { 
   Wallet,
   TrendingUp,
@@ -29,6 +31,7 @@ import {
 const Dashboard: React.FC = () => {
   const navigate = useNavigate();
   const { addToast } = useToast();
+  const { company } = useAuthContext();
   // Sample data for cash flow chart
   const cashFlowData = [
     { date: '01/07', inflow: 45000, outflow: 32000, balance: 13000 },
@@ -489,11 +492,12 @@ const Dashboard: React.FC = () => {
           </div>
         </Card>
       </div>
+        <SuggestedModulesWidget accountId={company?.id || ''} />
 
-      {/* Max Assistant */}
-      <MaxAssistant />
-    </div>
-  );
-};
+        {/* Max Assistant */}
+        <MaxAssistant />
+      </div>
+    );
+  };
 
 export default Dashboard;

--- a/src/pages/DashboardMobile.tsx
+++ b/src/pages/DashboardMobile.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import SuggestedModulesWidget from '../components/widgets/SuggestedModulesWidget';
+import { useAuthContext } from '../contexts/AuthContext';
+
+const DashboardMobile: React.FC = () => {
+  const { company } = useAuthContext();
+  return (
+    <div className="p-4">
+      {/* Graphique Cash-flow ici */}
+      <SuggestedModulesWidget accountId={company?.id || ''} />
+    </div>
+  );
+};
+
+export default DashboardMobile;


### PR DESCRIPTION
## Summary
- add SuggestedModulesWidget with analytics and feature flag
- hook useSuggestedModules to fetch module recommendations
- integrate widget into dashboard and add tests/docs

## Testing
- `npx vitest run src/__tests__/SuggestedModulesWidget.test.tsx`
- `npx cypress run --spec cypress/e2e/suggestedModulesWidget.cy.ts` *(fails: spawn Xvfb ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68909a2685c0832597f1952cbce26398