### PR TITLE
[Upsell P3] add trial subscription flow

### DIFF
--- a/api/subscription/trial.ts
+++ b/api/subscription/trial.ts
@@ -1,0 +1,54 @@
+import { FastifyPluginAsync } from 'fastify';
+import { supabase } from '../../src/lib/supabase';
+import { logTrialEvent } from '../../src/lib/hooks/useAnalytics';
+import { sendTrialStartedEmail } from '../../src/lib/hooks/useEmail';
+
+interface TrialBody {
+  accountId: string;
+  moduleId: string;
+}
+
+const TRIAL_DAYS = Number(process.env.TRIAL_DAYS || 7);
+
+const trialRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/api/subscription/trial-start', async (request, reply) => {
+    const { accountId, moduleId } = request.body as TrialBody;
+    const { data: existing } = await supabase
+      .from('subscriptions')
+      .select('id,status')
+      .eq('accountId', accountId)
+      .eq('moduleId', moduleId)
+      .in('status', ['trial', 'active'])
+      .maybeSingle();
+    if (existing) {
+      reply.code(409).send({ error: 'Module already active' });
+      return;
+    }
+    const trialStart = new Date();
+    const trialEnd = new Date(trialStart.getTime() + TRIAL_DAYS * 24 * 60 * 60 * 1000);
+    await supabase.from('subscriptions').insert({
+      accountId,
+      moduleId,
+      status: 'trial',
+      trialStart: trialStart.toISOString(),
+      trialEnd: trialEnd.toISOString()
+    });
+    await logTrialEvent('trialStarted', { accountId, moduleId });
+    await sendTrialStartedEmail(accountId, moduleId);
+    reply.send({ status: 'trial', trialEnd: trialEnd.toISOString() });
+  });
+
+  fastify.post('/api/subscription/cancel-trial', async (request, reply) => {
+    const { accountId, moduleId } = request.body as TrialBody;
+    await supabase
+      .from('subscriptions')
+      .update({ status: 'cancelled' })
+      .eq('accountId', accountId)
+      .eq('moduleId', moduleId)
+      .eq('status', 'trial');
+    await logTrialEvent('trialCancelled', { accountId, moduleId });
+    reply.send({ status: 'cancelled' });
+  });
+};
+
+export default trialRoute;

--- a/src/__tests__/trialApi.test.ts
+++ b/src/__tests__/trialApi.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import Fastify from 'fastify';
+import trialRoute from '../../api/subscription/trial';
+
+const records: any[] = [];
+
+vi.mock('../../src/lib/supabase', () => {
+  const from = () => ({
+    select: () => {
+      const filters: any = {};
+      const api: any = {
+        eq(field: string, value: any) {
+          filters[field] = value;
+          return api;
+        },
+        in(field: string, values: any[]) {
+          filters[field] = values;
+          return api;
+        },
+        async maybeSingle() {
+          const found = records.find(
+            (r) =>
+              r.accountId === filters.accountId &&
+              r.moduleId === filters.moduleId &&
+              (!filters.status || filters.status.includes(r.status))
+          );
+          return { data: found || null, error: null };
+        }
+      };
+      return api;
+    },
+    insert: async (record: any) => {
+      records.push(record);
+      return { data: record, error: null };
+    },
+    update: (values: any) => {
+      const filters: any = {};
+      const api: any = {
+        eq(field: string, value: any) {
+          filters[field] = value;
+          return api;
+        },
+        async then(resolve: any) {
+          const rec = records.find((r) =>
+            Object.entries(filters).every(([k, v]) => r[k] === v)
+          );
+          if (rec) Object.assign(rec, values);
+          return resolve({ data: rec ? [rec] : [], error: null });
+        }
+      };
+      return api;
+    }
+  });
+  return { supabase: { from } };
+});
+
+vi.mock('../../src/lib/hooks/useAnalytics', () => ({
+  logTrialEvent: vi.fn()
+}));
+
+vi.mock('../../src/lib/hooks/useEmail', () => ({
+  sendTrialStartedEmail: vi.fn()
+}));
+
+describe('trial API', () => {
+  it('starts trial', async () => {
+    records.length = 0;
+    const app = Fastify();
+    await app.register(trialRoute);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/subscription/trial-start',
+      payload: { accountId: 'a1', moduleId: 'm1' }
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.status).toBe('trial');
+    expect(records).toHaveLength(1);
+    await app.close();
+  });
+
+  it('returns 409 if already active', async () => {
+    records.length = 0;
+    records.push({ accountId: 'a1', moduleId: 'm1', status: 'trial' });
+    const app = Fastify();
+    await app.register(trialRoute);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/subscription/trial-start',
+      payload: { accountId: 'a1', moduleId: 'm1' }
+    });
+    expect(res.statusCode).toBe(409);
+    await app.close();
+  });
+});

--- a/src/__tests__/trialCron.test.ts
+++ b/src/__tests__/trialCron.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { convertExpiredTrials } from '../lib/cron/trialAutoConvert';
+
+const records: any[] = [
+  {
+    accountId: 'a1',
+    moduleId: 'm1',
+    status: 'trial',
+    trialEnd: '2020-01-01T00:00:00.000Z'
+  },
+  {
+    accountId: 'a2',
+    moduleId: 'm2',
+    status: 'trial',
+    trialEnd: '2999-01-01T00:00:00.000Z'
+  }
+];
+
+vi.mock('../lib/supabase', () => {
+  const from = () => ({
+    update: (values: any) => {
+      const filters: any = {};
+      const api: any = {
+        lt(field: string, value: string) {
+          filters[field] = { op: 'lt', value };
+          return api;
+        },
+        eq(field: string, value: string) {
+          filters[field] = { op: 'eq', value };
+          return api;
+        },
+        async then(resolve: any) {
+          for (const rec of records) {
+            const endCond =
+              filters.trialEnd &&
+              filters.trialEnd.op === 'lt' &&
+              new Date(rec.trialEnd) < new Date(filters.trialEnd.value);
+            const statusCond =
+              filters.status &&
+              filters.status.op === 'eq' &&
+              rec.status === filters.status.value;
+            if (endCond && statusCond) {
+              Object.assign(rec, values);
+            }
+          }
+          return resolve({ data: records, error: null });
+        }
+      };
+      return api;
+    }
+  });
+  return { supabase: { from } };
+});
+
+describe('trial auto convert', () => {
+  it('converts expired trials', async () => {
+    const now = new Date('2020-01-08T00:00:00.000Z');
+    await convertExpiredTrials(now);
+    const rec1 = records.find((r) => r.accountId === 'a1');
+    const rec2 = records.find((r) => r.accountId === 'a2');
+    expect(rec1?.status).toBe('active');
+    expect(rec1?.billingStart).toBe(now.toISOString());
+    expect(rec2?.status).toBe('trial');
+  });
+});

--- a/src/components/TrialBadge.tsx
+++ b/src/components/TrialBadge.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import Badge from './ui/Badge';
+
+const TrialBadge: React.FC = () => (
+  <Badge variant="primary" size="sm">
+    Essai actif (7 j)
+  </Badge>
+);
+
+export default TrialBadge;

--- a/src/components/TrialModal.tsx
+++ b/src/components/TrialModal.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Modal from './ui/Modal';
+import Button from './ui/Button';
+
+interface TrialModalProps {
+  isOpen: boolean;
+  moduleName: string;
+  benefit: string;
+  price: string;
+  onActivate: () => void;
+  onClose: () => void;
+}
+
+const TrialModal: React.FC<TrialModalProps> = ({
+  isOpen,
+  moduleName,
+  benefit,
+  price,
+  onActivate,
+  onClose
+}) => (
+  <Modal
+    isOpen={isOpen}
+    onClose={onClose}
+    title="Essai gratuit 7 j"
+    footer={
+      <>
+        <Button variant="primary" onClick={onActivate} className="mr-2">
+          Activer l'essai gratuit
+        </Button>
+        <Button variant="secondary" onClick={onClose}>
+          Annuler
+        </Button>
+      </>
+    }
+  >
+    <p className="font-medium mb-2">{moduleName}</p>
+    <p className="mb-2">{benefit}</p>
+    <p className="mb-2 text-sm text-gray-600">{price} / mois</p>
+    <p className="text-xs text-gray-500">Annulable à tout moment</p>
+  </Modal>
+);
+
+export default TrialModal;

--- a/src/emails/trialStarted.mjml
+++ b/src/emails/trialStarted.mjml
@@ -1,0 +1,9 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text>Votre essai gratuit pour {{moduleName}} est activé pour 7 jours.</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/src/lib/cron/trialAutoConvert.ts
+++ b/src/lib/cron/trialAutoConvert.ts
@@ -1,0 +1,9 @@
+import { supabase } from '../supabase';
+
+export async function convertExpiredTrials(now = new Date()) {
+  return await supabase
+    .from('subscriptions')
+    .update({ status: 'active', billingStart: now.toISOString() })
+    .lt('trialEnd', now.toISOString())
+    .eq('status', 'trial');
+}

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -40,3 +40,20 @@ export async function logRecoEvent(
     details
   });
 }
+
+export async function logTrialEvent(
+  event:
+    | 'trialStarted'
+    | 'trialCancelled'
+    | 'trialConverted'
+    | 'trialReminderEmailOpened',
+  payload: { accountId?: string | null; [key: string]: any }
+) {
+  const { accountId, ...details } = payload;
+  await supabase.from('analytics_events').insert({
+    account_id: accountId ?? null,
+    event,
+    timestamp: new Date().toISOString(),
+    details
+  });
+}

--- a/src/lib/hooks/useEmail.ts
+++ b/src/lib/hooks/useEmail.ts
@@ -1,0 +1,4 @@
+export async function sendTrialStartedEmail(accountId: string, moduleId: string) {
+  // Placeholder for transactional email send
+  return { accountId, moduleId };
+}

--- a/supabase/migrations/20250804130000_add_subscriptions_table.sql
+++ b/supabase/migrations/20250804130000_add_subscriptions_table.sql
@@ -1,0 +1,21 @@
+create table if not exists subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  accountId text not null,
+  moduleId text not null,
+  status text not null check (status in ('trial','active','cancelled')),
+  trialStart timestamptz,
+  trialEnd timestamptz,
+  billingStart timestamptz
+);
+
+create unique index if not exists subscriptions_account_module_idx
+  on subscriptions(accountId, moduleId)
+  where status in ('trial','active');
+
+select cron.schedule('trial_auto_convert', '0 0 * * *', $$
+  UPDATE subscriptions
+  SET    status = 'active',
+         billingStart = now()
+  WHERE  status   = 'trial'
+    AND  trialEnd < now();
+$$);


### PR DESCRIPTION
## Summary
- implement subscription trial start and cancel routes
- log trial analytics and send placeholder email
- add cron utility and migration for automatic trial conversion
- provide TrialModal, badge UI, and MJML email template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890a27b0e2083258560056ad7aac553