### PR TITLE
[Upsell P4] add email job queue and in-app notification scaffolding

### DIFF
--- a/emails/templates/day1_recap.mjml
+++ b/emails/templates/day1_recap.mjml
@@ -1,0 +1,10 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text>Vous avez déjà traité {{invoices}} factures. Découvrez le module recommandé {{module}}.</mj-text>
+        <mj-button href="https://app.example.com/dashboard?source=upsell_day1">Voir le widget</mj-button>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/emails/templates/day7_new_suggestions.mjml
+++ b/emails/templates/day7_new_suggestions.mjml
@@ -1,0 +1,10 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text>Découvrez de nouveaux modules qui pourraient vous intéresser.</mj-text>
+        <mj-button href="https://app.example.com/modules?source=upsell_day7">Voir les recommandations</mj-button>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/emails/templates/day7_trial_end.mjml
+++ b/emails/templates/day7_trial_end.mjml
@@ -1,0 +1,10 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text>Votre essai gratuit se termine dans 24h.</mj-text>
+        <mj-button href="https://app.example.com/billing?source=upsell_day7">Choisir une offre</mj-button>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/src/__tests__/enqueueEmailJobs.test.ts
+++ b/src/__tests__/enqueueEmailJobs.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { buildEmailJobs } from '../lib/cron/enqueueEmailJobs';
+
+const today = new Date('2024-01-08T09:00:00.000Z');
+const accounts = [
+  {
+    id: 'a1',
+    createdAt: '2024-01-07T09:00:00.000Z'
+  },
+  {
+    id: 'a2',
+    createdAt: '2024-01-01T09:00:00.000Z',
+    trialStatus: 'trial',
+    trialEnd: '2024-01-09T09:00:00.000Z'
+  },
+  {
+    id: 'a3',
+    createdAt: '2024-01-01T09:00:00.000Z',
+    trialStatus: 'none'
+  }
+];
+
+describe('email job builder', () => {
+  it('selects templates according to context', () => {
+    const jobs = buildEmailJobs(accounts as any, today);
+    expect(jobs).toHaveLength(3);
+    expect(jobs.find((j) => j.accountId === 'a1')?.template).toBe('day1_recap');
+    expect(jobs.find((j) => j.accountId === 'a2')?.template).toBe(
+      'day7_trial_end'
+    );
+    expect(jobs.find((j) => j.accountId === 'a3')?.template).toBe(
+      'day7_new_suggestions'
+    );
+  });
+});

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { Bell } from 'lucide-react';
+import Modal from './ui/Modal';
+import Button from './ui/Button';
+import { useNotifications } from '../lib/hooks/useNotifications';
+
+interface Props {
+  accountId: string;
+}
+
+const Notifications: React.FC<Props> = ({ accountId }) => {
+  const notifications = useNotifications(accountId);
+  const [isOpen, setOpen] = useState(false);
+  const current = notifications[0];
+
+  return (
+    <>
+      <button
+        aria-label="Notifications"
+        className="relative"
+        onClick={() => setOpen(true)}
+      >
+        <Bell />
+        {notifications.length > 0 && (
+          <span className="absolute -top-1 -right-1 text-xs bg-red-500 text-white rounded-full px-1">
+            {notifications.length}
+          </span>
+        )}
+      </button>
+      {current && (
+        <Modal
+          isOpen={isOpen}
+          onClose={() => setOpen(false)}
+          title="Notification"
+          footer={
+            current.payload?.cta ? (
+              <Button asChild>
+                <a
+                  href={current.payload.cta}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Ouvrir
+                </a>
+              </Button>
+            ) : null
+          }
+        >
+          <p>{current.payload?.message || ''}</p>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default Notifications;

--- a/src/emails/render.ts
+++ b/src/emails/render.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import mjml2html from '@mjml/core';
+
+export type TemplateName =
+  | 'day1_recap'
+  | 'day7_trial_end'
+  | 'day7_new_suggestions';
+
+export function renderEmail(
+  template: TemplateName,
+  variables: Record<string, string>
+) {
+  const file = resolve('emails/templates', `${template}.mjml`);
+  let mjml = readFileSync(file, 'utf8');
+  for (const [key, value] of Object.entries(variables)) {
+    mjml = mjml.replace(new RegExp(`{{${key}}}`, 'g'), value);
+  }
+  const { html } = mjml2html(mjml);
+  return html;
+}

--- a/src/lib/cron/enqueueEmailJobs.ts
+++ b/src/lib/cron/enqueueEmailJobs.ts
@@ -1,0 +1,77 @@
+import { supabase } from '../supabase';
+
+export interface Account {
+  id: string;
+  createdAt: string;
+  trialStatus?: string | null;
+  trialEnd?: string | null;
+}
+
+export interface EmailJob {
+  accountId: string;
+  template: string;
+  payload: Record<string, any>;
+}
+
+function isTomorrow(dateStr: string | null | undefined, today: Date) {
+  if (!dateStr) return false;
+  const diff = new Date(dateStr).getTime() - today.getTime();
+  return diff > 0 && diff <= 24 * 60 * 60 * 1000;
+}
+
+export function buildEmailJobs(accounts: Account[], today: Date): EmailJob[] {
+  const jobs: EmailJob[] = [];
+  for (const acc of accounts) {
+    const created = new Date(acc.createdAt);
+    const days = Math.floor(
+      (today.getTime() - created.getTime()) / (24 * 60 * 60 * 1000)
+    );
+    if (days === 1) {
+      jobs.push({
+        accountId: acc.id,
+        template: 'day1_recap',
+        payload: { utm: 'upsell_day1' }
+      });
+    } else if (days === 7) {
+      if (acc.trialStatus === 'trial' && isTomorrow(acc.trialEnd, today)) {
+        jobs.push({
+          accountId: acc.id,
+          template: 'day7_trial_end',
+          payload: { utm: 'upsell_day7' }
+        });
+      } else {
+        jobs.push({
+          accountId: acc.id,
+          template: 'day7_new_suggestions',
+          payload: { utm: 'upsell_day7' }
+        });
+      }
+    }
+  }
+  return jobs;
+}
+
+export async function enqueueEmailJobs(today = new Date()) {
+  const sevenDaysAgo = new Date(today);
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const { data } = await supabase
+    .from('accounts')
+    .select('id, created_at, trial_status, trial_end')
+    .eq('status', 'active')
+    .gte('created_at', sevenDaysAgo.toISOString());
+  const accounts: Account[] = (data || []).map((d: any) => ({
+    id: d.id,
+    createdAt: d.created_at,
+    trialStatus: d.trial_status,
+    trialEnd: d.trial_end
+  }));
+  const jobs = buildEmailJobs(accounts, today);
+  for (const job of jobs) {
+    await supabase.from('email_jobs').insert({
+      account_id: job.accountId,
+      template: job.template,
+      payload: job.payload
+    });
+  }
+  return jobs.length;
+}

--- a/src/lib/hooks/useNotifications.ts
+++ b/src/lib/hooks/useNotifications.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabase';
+
+export interface InappNotification {
+  id: string;
+  account_id: string;
+  type: string;
+  payload: Record<string, any>;
+  seen_at: string | null;
+}
+
+export function useNotifications(accountId: string | null) {
+  const [notifications, setNotifications] = useState<InappNotification[]>([]);
+
+  useEffect(() => {
+    if (!accountId) return;
+    supabase
+      .from('inapp_notifications')
+      .select('*')
+      .eq('account_id', accountId)
+      .is('seen_at', null)
+      .then(({ data }) => {
+        setNotifications((data as InappNotification[]) || []);
+      });
+  }, [accountId]);
+
+  return notifications;
+}

--- a/supabase/functions/enqueue_email_jobs.ts
+++ b/supabase/functions/enqueue_email_jobs.ts
@@ -1,0 +1,35 @@
+import { createClient } from '@supabase/supabase-js';
+import { buildEmailJobs } from '../../src/lib/cron/enqueueEmailJobs.ts';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const supabase = createClient(supabaseUrl, serviceKey);
+
+Deno.serve(async () => {
+  const today = new Date();
+  const sevenDaysAgo = new Date(today);
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const { data } = await supabase
+    .from('accounts')
+    .select('id, created_at, trial_status, trial_end')
+    .eq('status', 'active')
+    .gte('created_at', sevenDaysAgo.toISOString());
+  const accounts = (data || []).map((d: any) => ({
+    id: d.id,
+    createdAt: d.created_at,
+    trialStatus: d.trial_status,
+    trialEnd: d.trial_end
+  }));
+  const jobs = buildEmailJobs(accounts, today);
+  for (const job of jobs) {
+    await supabase.from('email_jobs').insert({
+      account_id: job.accountId,
+      template: job.template,
+      payload: job.payload
+    });
+  }
+  return new Response(
+    JSON.stringify({ inserted: jobs.length }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+});

--- a/supabase/migrations/20250810120000_add_email_inapp_notifications.sql
+++ b/supabase/migrations/20250810120000_add_email_inapp_notifications.sql
@@ -1,0 +1,29 @@
+-- Email jobs queue
+create table if not exists email_jobs (
+  id uuid primary key default gen_random_uuid(),
+  account_id uuid references accounts(id),
+  template text not null,
+  payload jsonb,
+  created_at timestamptz default now()
+);
+
+-- In-app notifications table
+create table if not exists inapp_notifications (
+  id uuid primary key default gen_random_uuid(),
+  account_id uuid references accounts(id),
+  type text not null,
+  payload jsonb,
+  seen_at timestamptz
+);
+
+alter table email_jobs enable row level security;
+alter table inapp_notifications enable row level security;
+
+create policy "Users select own email jobs" on email_jobs
+  for select using (account_id = auth.uid());
+
+create policy "Users manage own notifications" on inapp_notifications
+  for all using (account_id = auth.uid());
+
+-- Cron job to enqueue emails at 09:00 CET daily
+select cron.schedule('daily_email_job', '0 9 * * *', $$select enqueue_email_jobs();$$);


### PR DESCRIPTION
## Summary
- scaffold Supabase edge function to enqueue day1/day7 upsell emails
- add email_jobs & inapp_notifications tables with cron schedule
- provide MJML templates, render helper, notification hook & component

## Testing
- `npm test -- --run`
- `npx cypress run` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6890a58e6cc08325a1fb30b10b199fd1