### PR TITLE
feat: add upsell KPI daily view

### DIFF
--- a/supabase/migrations/20250820120000_add_upsell_kpi_view.sql
+++ b/supabase/migrations/20250820120000_add_upsell_kpi_view.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW v_upsell_kpi_daily AS
+SELECT
+    current_date AS day,
+    COUNT(DISTINCT account_id) FILTER (WHERE modules_added > 0)
+        * 1.0 / COUNT(DISTINCT account_id)                     AS upsell_rate,
+    SUM(mrr)::float / COUNT(DISTINCT account_id)               AS mrr_avg,
+    SUM(reco_activated)::float / NULLIF(SUM(reco_served), 0)   AS activation_rate,
+    SUM(churn_upsell)::float / NULLIF(COUNT(DISTINCT account_id), 0) AS churn_upsell
+FROM metrics_daily
+WHERE day = current_date;


### PR DESCRIPTION
## Summary
- add SQL view `v_upsell_kpi_daily` aggregating upsell metrics

## Testing
- `CI=1 npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6890adcaf5988325a50e27313fef27ab