### PR TITLE
[Advisory S2] add expert contact widget

### DIFF
--- a/api/experts/index.ts
+++ b/api/experts/index.ts
@@ -1,0 +1,27 @@
+import { FastifyPluginAsync } from 'fastify';
+
+interface ExpertResponse {
+  id: string;
+  name: string;
+  speciality: string;
+  avatarUrl: string;
+  online: boolean;
+  npsScore: number;
+}
+
+const expertsRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/api/experts/:id', async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const expert: ExpertResponse = {
+      id,
+      name: 'Julie Bernard',
+      speciality: 'Fiscalité PME',
+      avatarUrl: 'https://placekitten.com/200/200',
+      online: true,
+      npsScore: 87
+    };
+    reply.send(expert);
+  });
+};
+
+export default expertsRoute;

--- a/cypress/e2e/expertContactWidget.cy.ts
+++ b/cypress/e2e/expertContactWidget.cy.ts
@@ -1,0 +1,31 @@
+describe('ExpertContactWidget', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/api/experts/*', {
+      body: {
+        id: 'exp1',
+        name: 'Julie Bernard',
+        speciality: 'Fiscalité PME',
+        avatarUrl: 'https://placekitten.com/200/200',
+        online: true,
+        npsScore: 90
+      }
+    });
+    cy.intercept('GET', '**/rest/v1/feature_flags*', {
+      body: [{ is_enabled: true }]
+    });
+  });
+
+  it('desktop: widget visible and plan call opens modal', () => {
+    cy.viewport(1280, 720);
+    cy.visit('/');
+    cy.contains('Planifier un appel').click();
+    cy.contains('Fonctionnalité à venir').should('be.visible');
+  });
+
+  it('mobile: widget full width and links work', () => {
+    cy.viewport(375, 667);
+    cy.visit('/');
+    cy.contains('Envoyer un message').click();
+    cy.url().should('include', '/messages/new?to=exp1');
+  });
+});

--- a/src/__tests__/ExpertContactWidget.test.tsx
+++ b/src/__tests__/ExpertContactWidget.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import ExpertContactWidget from '../components/widgets/ExpertContactWidget';
+import { useExpertDetails } from '../lib/hooks/useExpertDetails';
+import { useFeatureFlag } from '../lib/hooks/useFeatureFlag';
+import { logAdvisoryEvent } from '../lib/hooks/useAnalytics';
+
+vi.mock('../lib/hooks/useExpertDetails');
+vi.mock('../lib/hooks/useFeatureFlag');
+vi.mock('../lib/hooks/useAnalytics');
+
+describe('<ExpertContactWidget />', () => {
+  it('renders expert info and logs view', () => {
+    (useFeatureFlag as unknown as vi.Mock).mockReturnValue({ enabled: true });
+    (useExpertDetails as unknown as vi.Mock).mockReturnValue({
+      expert: {
+        id: 'exp1',
+        name: 'Jean Martin',
+        speciality: 'Fiscalité PME',
+        avatarUrl: '',
+        online: true,
+        npsScore: 90
+      },
+      isLoading: false
+    });
+
+    render(<ExpertContactWidget accountId="acc1" />);
+
+    expect(screen.getByText('Jean Martin')).toBeInTheDocument();
+    expect(screen.getByText('Fiscalité PME')).toBeInTheDocument();
+    expect(logAdvisoryEvent).toHaveBeenCalledWith('expertWidgetViewed', {
+      accountId: 'acc1',
+      expertId: 'exp1'
+    });
+  });
+});

--- a/src/components/BookingModal.tsx
+++ b/src/components/BookingModal.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Modal from './ui/Modal';
+
+interface BookingModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  expertName: string;
+}
+
+const BookingModal: React.FC<BookingModalProps> = ({ isOpen, onClose, expertName }) => (
+  <Modal isOpen={isOpen} onClose={onClose} title={expertName}>
+    <p>{/** i18n key: advisor.bookingModal.placeholder */} Fonctionnalité à venir</p>
+  </Modal>
+);
+
+export default BookingModal;

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -63,6 +63,7 @@ const Avatar: React.FC<AvatarProps> = ({
             src={src}
             alt={alt || 'Avatar'}
             className="w-full h-full object-cover"
+            loading="lazy"
           />
         ) : (
           getFallbackContent()

--- a/src/components/widgets/ExpertContactWidget.tsx
+++ b/src/components/widgets/ExpertContactWidget.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+import { useFeatureFlag } from '../../lib/hooks/useFeatureFlag';
+import { useExpertDetails } from '../../lib/hooks/useExpertDetails';
+import { logAdvisoryEvent } from '../../lib/hooks/useAnalytics';
+import BookingModal from '../BookingModal';
+
+interface Props {
+  accountId: string;
+}
+
+const ExpertContactWidget: React.FC<Props> = ({ accountId }) => {
+  const { enabled } = useFeatureFlag('advisoryV1');
+  const { expert, isLoading } = useExpertDetails(accountId);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (enabled && expert) {
+      void logAdvisoryEvent('expertWidgetViewed', {
+        accountId,
+        expertId: expert.id
+      });
+    }
+  }, [enabled, expert, accountId]);
+
+  if (!enabled) return null;
+
+  if (isLoading) {
+    return (
+      <Card className="p-4 flex items-center space-x-4" role="region">
+        <div className="w-10 h-10 rounded-full bg-gray-200 animate-pulse" />
+        <div className="flex-1 space-y-2">
+          <div className="h-4 bg-gray-200 rounded animate-pulse w-1/2" />
+          <div className="h-3 bg-gray-200 rounded animate-pulse w-1/3" />
+        </div>
+      </Card>
+    );
+  }
+
+  if (!expert) return null;
+
+  const npsEmoji = expert.npsScore >= 80 ? '😊' : expert.npsScore >= 50 ? '😐' : '😞';
+
+  return (
+    <>
+      <Card role="region" className="p-4 flex items-center space-x-4">
+        <div className="relative">
+          <img
+            src={expert.avatarUrl}
+            alt={expert.name}
+            className="w-10 h-10 rounded-full object-cover"
+            loading="lazy"
+          />
+          <span
+            className={`absolute bottom-0 right-0 block h-2.5 w-2.5 rounded-full ring-2 ring-white ${
+              expert.online ? 'bg-success' : 'bg-error'
+            }`}
+          ></span>
+        </div>
+        <div className="flex-1">
+          <h4 className="font-medium text-gray-900">{expert.name}</h4>
+          <p className="text-sm text-gray-500">{expert.speciality}</p>
+          <p className="text-sm mt-1">
+            {npsEmoji} {expert.npsScore}/100
+          </p>
+        </div>
+        <div className="flex flex-col space-y-2">
+          <Button
+            variant="primary"
+            onClick={() => {
+              void logAdvisoryEvent('expertPlanCallClicked', {
+                accountId,
+                expertId: expert.id
+              });
+              setOpen(true);
+            }}
+          >
+            Planifier un appel
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              void logAdvisoryEvent('expertMessageClicked', {
+                accountId,
+                expertId: expert.id
+              });
+              window.location.href = `/messages/new?to=${expert.id}`;
+            }}
+          >
+            Envoyer un message
+          </Button>
+        </div>
+      </Card>
+      <BookingModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        expertName={expert.name}
+      />
+    </>
+  );
+};
+
+export default ExpertContactWidget;

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -57,3 +57,16 @@ export async function logTrialEvent(
     details
   });
 }
+
+export async function logAdvisoryEvent(
+  event: 'expertWidgetViewed' | 'expertPlanCallClicked' | 'expertMessageClicked',
+  payload: { accountId?: string | null; expertId?: string; [key: string]: any }
+) {
+  const { accountId, ...details } = payload;
+  await supabase.from('analytics_events').insert({
+    account_id: accountId ?? null,
+    event,
+    timestamp: new Date().toISOString(),
+    details
+  });
+}

--- a/src/lib/hooks/useExpertDetails.ts
+++ b/src/lib/hooks/useExpertDetails.ts
@@ -1,0 +1,27 @@
+import useSWR from '../useSWR';
+
+export interface ExpertDetails {
+  id: string;
+  name: string;
+  speciality: string;
+  avatarUrl: string;
+  online: boolean;
+  npsScore: number;
+}
+
+export function useExpertDetails(accountId: string) {
+  if (!accountId) {
+    return { expert: undefined, isLoading: false, error: null } as const;
+  }
+
+  const fetcher = () =>
+    fetch(`/api/experts/${accountId}`).then((r) => r.json() as Promise<ExpertDetails>);
+
+  const { data, error } = useSWR(`/api/experts/${accountId}`, fetcher);
+
+  return {
+    expert: data,
+    isLoading: !data && !error,
+    error
+  } as const;
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import Charts from '../components/ui/Charts';
 import MaxAssistant from '../components/ui/MaxAssistant';
 import { useToast } from '../contexts/ToastContext';
 import SuggestedModulesWidget from '../components/widgets/SuggestedModulesWidget';
+import ExpertContactWidget from '../components/widgets/ExpertContactWidget';
 import { useAuthContext } from '../contexts/AuthContext';
 import { 
   Wallet,
@@ -493,6 +494,7 @@ const Dashboard: React.FC = () => {
         </Card>
       </div>
         <SuggestedModulesWidget accountId={company?.id || ''} />
+        <ExpertContactWidget accountId={company?.id || ''} />
 
         {/* Max Assistant */}
         <MaxAssistant />

--- a/src/pages/DashboardMobile.tsx
+++ b/src/pages/DashboardMobile.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SuggestedModulesWidget from '../components/widgets/SuggestedModulesWidget';
+import ExpertContactWidget from '../components/widgets/ExpertContactWidget';
 import { useAuthContext } from '../contexts/AuthContext';
 
 const DashboardMobile: React.FC = () => {
@@ -8,6 +9,7 @@ const DashboardMobile: React.FC = () => {
     <div className="p-4">
       {/* Graphique Cash-flow ici */}
       <SuggestedModulesWidget accountId={company?.id || ''} />
+      <ExpertContactWidget accountId={company?.id || ''} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add expert details hook with API stub and analytics
- display contact widget allowing users to plan calls or send messages to their expert
- cover widget with unit and Cypress tests

## Testing
- `npm test` (errors: Vitest caught 2 unhandled errors)
- `npx cypress run --spec cypress/e2e/expertContactWidget.cy.ts` (fails: missing Xvfb)


------
https://chatgpt.com/codex/tasks/task_e_6890c764d11483258dc043eb9b9f99f6