### PR TITLE
feat: add advisory referral workflow

### DIFF
--- a/api/advisory/accept.ts
+++ b/api/advisory/accept.ts
@@ -1,0 +1,25 @@
+import { FastifyPluginAsync } from 'fastify';
+import { supabase } from '../../src/lib/supabase';
+
+interface AcceptBody {
+  sessionId: string;
+  startAt: string;
+}
+
+async function generateMeetingLink(sessionId: string) {
+  return `https://whereby.com/${sessionId}`;
+}
+
+const acceptRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/api/advisory/accept', async (request, reply) => {
+    const { sessionId, startAt } = request.body as AcceptBody;
+    const meetingUrl = await generateMeetingLink(sessionId);
+    await supabase
+      .from('advisory_sessions')
+      .update({ status: 'scheduled', start_at: startAt, meeting_url: meetingUrl })
+      .eq('id', sessionId);
+    reply.send({ meetingUrl });
+  });
+};
+
+export default acceptRoute;

--- a/api/advisory/referral.ts
+++ b/api/advisory/referral.ts
@@ -1,0 +1,58 @@
+import { FastifyPluginAsync } from 'fastify';
+import { randomUUID } from 'crypto';
+import { supabase } from '../../src/lib/supabase';
+
+interface ReferralBody {
+  accountId: string;
+  topic: string;
+  preferredTimeSlots: string[];
+}
+
+function decodeToken(auth?: string) {
+  if (!auth?.startsWith('Bearer ')) return null;
+  try {
+    return JSON.parse(Buffer.from(auth.slice(7), 'base64').toString());
+  } catch {
+    return null;
+  }
+}
+
+const referralRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/api/advisory/referral', async (request, reply) => {
+    const user = decodeToken(request.headers.authorization as string);
+    const { accountId, topic } = request.body as ReferralBody;
+    if (!user || user.role !== 'expert' || user.accountId !== accountId) {
+      reply.code(401).send({ error: 'Unauthorized' });
+      return;
+    }
+
+    const { data: allSpecs } = await supabase.from('specialists').select('*');
+    const specialist = (allSpecs || [])
+      .filter((s: any) => s.sectors.includes(topic))
+      .filter((s: any) => s.current_load < s.max_load)
+      .sort((a: any, b: any) => a.current_load - b.current_load)[0];
+
+    if (!specialist) {
+      reply.code(404).send({ error: 'No specialist available' });
+      return;
+    }
+
+    const session = {
+      id: randomUUID(),
+      account_id: accountId,
+      expert_id: user.id,
+      specialist_id: specialist.id,
+      status: 'pending',
+      created_at: new Date().toISOString()
+    };
+    await supabase.from('advisory_sessions').insert(session);
+    await supabase
+      .from('specialists')
+      .update({ current_load: specialist.current_load + 1 })
+      .eq('id', specialist.id);
+
+    reply.send({ sessionId: session.id, specialistId: specialist.id });
+  });
+};
+
+export default referralRoute;

--- a/src/__tests__/advisoryApi.test.ts
+++ b/src/__tests__/advisoryApi.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Fastify from 'fastify';
+import referralRoute from '../../api/advisory/referral';
+import acceptRoute from '../../api/advisory/accept';
+
+const specialists: any[] = [];
+const sessions: any[] = [];
+
+vi.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    from(table: string) {
+      if (table === 'specialists') {
+        return {
+          select: async () => ({ data: specialists }),
+          update(values: any) {
+            return {
+              eq(field: string, value: any) {
+                const rec = specialists.find((s) => s[field] === value);
+                if (rec) Object.assign(rec, values);
+                return Promise.resolve({ data: rec ? [rec] : [] });
+              }
+            };
+          }
+        };
+      }
+      if (table === 'advisory_sessions') {
+        return {
+          insert: async (record: any) => {
+            sessions.push(record);
+            return { data: record };
+          },
+          update(values: any) {
+            return {
+              eq(field: string, value: any) {
+                const rec = sessions.find((s) => s[field] === value);
+                if (rec) Object.assign(rec, values);
+                return Promise.resolve({ data: rec ? [rec] : [] });
+              }
+            };
+          }
+        };
+      }
+      return {} as any;
+    }
+  }
+}));
+
+describe('advisory API', () => {
+  beforeEach(() => {
+    specialists.length = 0;
+    sessions.length = 0;
+  });
+
+  it('refers a client to a specialist', async () => {
+    specialists.push(
+      { id: 's1', name: 'Spec1', sectors: ['tax'], languages: ['fr'], rating: 5, max_load: 2, current_load: 0 },
+      { id: 's2', name: 'Spec2', sectors: ['tax'], languages: ['fr'], rating: 4, max_load: 2, current_load: 1 }
+    );
+    const app = Fastify();
+    await app.register(referralRoute);
+    const token = Buffer.from(JSON.stringify({ id: 'e1', role: 'expert', accountId: 'a1' })).toString('base64');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/advisory/referral',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { accountId: 'a1', topic: 'tax', preferredTimeSlots: [] }
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.payload);
+    expect(body.specialistId).toBe('s1');
+    expect(sessions).toHaveLength(1);
+    expect(specialists[0].current_load).toBe(1);
+    await app.close();
+  });
+
+  it('accepts a session', async () => {
+    sessions.push({ id: 'sess1', account_id: 'a1', expert_id: 'e1', specialist_id: 's1', status: 'pending', created_at: '' });
+    const app = Fastify();
+    await app.register(acceptRoute);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/advisory/accept',
+      payload: { sessionId: 'sess1', startAt: '2024-01-01T10:00:00Z' }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(sessions[0].status).toBe('scheduled');
+    expect(sessions[0].meeting_url).toMatch(/https:\/\/whereby.com\/sess1/);
+    await app.close();
+  });
+});

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -538,6 +538,67 @@ export interface Database {
           current_load?: number
         }
       }
+      ,specialists: {
+        Row: {
+          id: string
+          name: string
+          sectors: string[]
+          languages: string[]
+          rating: number
+          max_load: number
+          current_load: number
+        }
+        Insert: {
+          id?: string
+          name: string
+          sectors: string[]
+          languages: string[]
+          rating: number
+          max_load?: number
+          current_load?: number
+        }
+        Update: {
+          id?: string
+          name?: string
+          sectors?: string[]
+          languages?: string[]
+          rating?: number
+          max_load?: number
+          current_load?: number
+        }
+      }
+      ,advisory_sessions: {
+        Row: {
+          id: string
+          account_id: string
+          expert_id: string
+          specialist_id: string
+          status: string
+          created_at: string
+          start_at: string | null
+          meeting_url: string | null
+        }
+        Insert: {
+          id?: string
+          account_id: string
+          expert_id: string
+          specialist_id: string
+          status?: string
+          created_at?: string
+          start_at?: string | null
+          meeting_url?: string | null
+        }
+        Update: {
+          id?: string
+          account_id?: string
+          expert_id?: string
+          specialist_id?: string
+          status?: string
+          created_at?: string
+          start_at?: string | null
+          meeting_url?: string | null
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add specialist referral endpoint selecting available specialist and creating pending session
- allow specialist to accept session and generate meeting link
- define specialists and advisory_sessions tables

## Testing
- `CI=1 npx vitest run src/__tests__/advisoryApi.test.ts`
- `npm run lint` *(fails: React Hooks called conditionally)*

------
https://chatgpt.com/codex/tasks/task_e_6890cc63c9e08325960f4dab7a521056