### PR TITLE
feat: add advisory KPI daily view

### DIFF
--- a/supabase/migrations/20250901120000_add_advisory_kpi_view.sql
+++ b/supabase/migrations/20250901120000_add_advisory_kpi_view.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW v_advisory_kpi_daily AS
+SELECT
+    current_date                                                  AS day,
+    COUNT(*) FILTER (WHERE status='confirmed')                    AS sessions_planned,
+    COUNT(*) FILTER (WHERE status='completed')                    AS sessions_done,
+    SUM(price_cents)/100.0                                        AS revenue_eur,
+    AVG(nps_score)                                                AS nps_avg,
+    AVG(EXTRACT(EPOCH FROM (start_at - created_at))/3600)         AS sla_hours
+FROM advisory_sessions
+WHERE created_at::date = current_date;


### PR DESCRIPTION
## Summary
- add SQL view `v_advisory_kpi_daily` to track sessions, revenue, NPS, and SLA metrics for advisory service

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook rule errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6890e174006c832591cd4ee70639e482