### PR TITLE
feat(bundle): add dynamic discount engine

### DIFF
--- a/src/__tests__/discountEngine.test.ts
+++ b/src/__tests__/discountEngine.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getDiscountPct } from '../bundle/discountEngine';
+
+describe('getDiscountPct', () => {
+  it('returns 5 for score greater than 0.8', () => {
+    expect(getDiscountPct(0.81)).toBe(5);
+    expect(getDiscountPct(0.9)).toBe(5);
+  });
+
+  it('returns 10 for score greater than 0.6 and up to 0.8', () => {
+    expect(getDiscountPct(0.61)).toBe(10);
+    expect(getDiscountPct(0.8)).toBe(10);
+  });
+
+  it('returns 15 for score 0.6 or less', () => {
+    expect(getDiscountPct(0.6)).toBe(15);
+    expect(getDiscountPct(0.3)).toBe(15);
+  });
+});

--- a/src/bundle/discountEngine.ts
+++ b/src/bundle/discountEngine.ts
@@ -1,0 +1,5 @@
+export function getDiscountPct(score: number) {
+  if (score > 0.8) return 5;
+  if (score > 0.6) return 10;
+  return 15;
+}


### PR DESCRIPTION
## Summary
- add discountEngine to calculate dynamic discount
- cover discount engine with unit tests

## Testing
- `npm test` *(fails: Worker terminated due to memory limit)*
- `npm run lint` *(fails: React Hook useState/useEffect called conditionally)*

------
https://chatgpt.com/codex/tasks/task_e_6891055fdb908325a12d514d00efee73