### PR TITLE
feat: add discount model retraining and rollout

### DIFF
--- a/supabase/functions/retrain_discount_model.ts
+++ b/supabase/functions/retrain_discount_model.ts
@@ -1,0 +1,56 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const supabase = createClient(supabaseUrl, serviceKey);
+
+Deno.serve(async () => {
+  const since = new Date();
+  since.setDate(since.getDate() - 60);
+  const { data, error } = await supabase
+    .from('bundle_metrics')
+    .select('*')
+    .gte('created_at', since.toISOString());
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 });
+  }
+  const rows = data || [];
+  if (rows.length) {
+    const headers = Object.keys(rows[0]);
+    const csvLines = [headers.join(',')];
+    for (const row of rows) {
+      csvLines.push(headers.map(h => JSON.stringify((row as any)[h] ?? '')).join(','));
+    }
+    await Deno.writeTextFile('/tmp/data.csv', csvLines.join('\n'));
+  }
+
+  const cmd = new Deno.Command('docker', {
+    args: ['run', '--rm', '-v', '/tmp:/tmp', 'ml-discount-trainer']
+  });
+  const { code, stderr } = await cmd.output();
+  if (code !== 0) {
+    return new Response(new TextDecoder().decode(stderr), { status: 500 });
+  }
+
+  const today = new Date().toISOString().split('T')[0];
+  const folder = `discount/${today}`;
+  const model = await Deno.readFile('/tmp/model.pkl');
+  await supabase.storage
+    .from('ml-models')
+    .upload(`${folder}/model.pkl`, model, { contentType: 'application/octet-stream', upsert: true });
+  const metricsText = await Deno.readTextFile('/tmp/metrics.json');
+  await supabase.storage
+    .from('ml-models')
+    .upload(`${folder}/metrics.json`, new TextEncoder().encode(metricsText), { contentType: 'application/json', upsert: true });
+
+  const metrics = JSON.parse(metricsText);
+  await supabase.from('model_versions').insert({
+    path: `${folder}/model.pkl`,
+    auc: metrics.auc,
+    rev_sim: metrics.revSim
+  });
+
+  return new Response(JSON.stringify({ status: 'ok' }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+});

--- a/supabase/migrations/20250920120000_add_discount_model_versions.sql
+++ b/supabase/migrations/20250920120000_add_discount_model_versions.sql
@@ -1,0 +1,81 @@
+-- Create table to track discount model versions and rollout
+create table if not exists model_versions (
+  id bigint generated always as identity primary key,
+  path text not null,
+  auc float not null,
+  rev_sim float not null,
+  is_prod boolean default false,
+  traffic_pct int default 0,
+  created_at timestamptz default now()
+);
+
+-- Approve the latest trained model if metrics meet thresholds
+create or replace function approve_new_model()
+returns void
+language plpgsql
+as $$
+declare
+  prod_auc float;
+  new_auc float;
+  rev_delta float;
+  new_id bigint;
+begin
+  select auc into prod_auc
+  from model_versions
+  where is_prod = true
+  order by created_at desc
+  limit 1;
+
+  select id, auc, rev_sim into new_id, new_auc, rev_delta
+  from model_versions
+  where is_prod = false
+  order by created_at desc
+  limit 1;
+
+  if new_id is null then
+    return;
+  end if;
+
+  if new_auc >= prod_auc - 0.01 and rev_delta >= 0.02 then
+    update model_versions set is_prod = false, traffic_pct = 0 where is_prod = true;
+    update model_versions set is_prod = true, traffic_pct = 10 where id = new_id;
+  end if;
+end;
+$$;
+
+-- Rollout checker: after 48h move to 100% or rollback
+create or replace function finalize_model_rollout()
+returns void
+language plpgsql
+as $$
+declare
+  current_prod model_versions;
+  previous_prod model_versions;
+begin
+  select * into current_prod
+  from model_versions
+  where is_prod = true
+  order by created_at desc
+  limit 1;
+
+  if current_prod.traffic_pct = 10 and current_prod.created_at <= now() - interval '48 hours' then
+    -- simplistic KPI check using rev_sim
+    if current_prod.rev_sim >= 0.02 then
+      update model_versions set traffic_pct = 100 where id = current_prod.id;
+    else
+      select * into previous_prod
+      from model_versions
+      where id <> current_prod.id and traffic_pct = 100
+      order by created_at desc
+      limit 1;
+      if previous_prod.id is not null then
+        update model_versions set is_prod = true, traffic_pct = 100 where id = previous_prod.id;
+      end if;
+      update model_versions set is_prod = false, traffic_pct = 0 where id = current_prod.id;
+    end if;
+  end if;
+end;
+$$;
+
+-- Schedule rollout check hourly
+select cron.schedule('discount_model_rollout', '0 * * * *', $$select finalize_model_rollout();$$);


### PR DESCRIPTION
## Summary
- add edge function to retrain discount model and store artifacts
- introduce model_versions table with approval and rollout helpers

## Testing
- `npm test`
- `npm run lint` *(fails: React Hooks rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_68910fb070748325a7c8e7bb6ca27864