### PR TITLE
feat: add AI entry generation service

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "recharts": "^2.12.2",
     "@supabase/supabase-js": "^2.39.7",
     "fastify": "^4.26.2",
-    "@fastify/multipart": "^7.7.1"
+    "@fastify/multipart": "^7.7.1",
+    "openai": "^4.57.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/prompts/journal_entry_prompt.txt
+++ b/prompts/journal_entry_prompt.txt
@@ -1,0 +1,15 @@
+You are an accounting assistant. Based on the provided invoice extract,
+business rules, and past examples, suggest the appropriate accounting
+entry.
+
+Invoice:
+{{invoice}}
+
+Rules:
+{{rules}}
+
+Examples:
+{{examples}}
+
+Return only a JSON object with the following keys:
+vatCode, accountDebit, accountCredit, amount, description.

--- a/src/lib/aiEntryGenerator.ts
+++ b/src/lib/aiEntryGenerator.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { openai } from '@/lib/openai';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const templatePath = path.resolve(__dirname, '../../prompts/journal_entry_prompt.txt');
+const template = readFileSync(templatePath, 'utf-8');
+
+export function buildPrompt(payload: {
+  invoice: unknown;
+  rules: unknown;
+  examples?: unknown;
+}) {
+  const content = template
+    .replace('{{invoice}}', JSON.stringify(payload.invoice))
+    .replace('{{rules}}', JSON.stringify(payload.rules))
+    .replace('{{examples}}', JSON.stringify(payload.examples ?? []));
+
+  return [
+    {
+      role: 'system',
+      content: 'You are an expert accounting assistant generating journal entries.',
+    },
+    {
+      role: 'user',
+      content,
+    },
+  ];
+}
+
+export async function generateEntry(payload: {
+  invoice: unknown;
+  rules: unknown;
+  examples?: unknown;
+}) {
+  const { choices } = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    temperature: 0.2,
+    messages: buildPrompt(payload),
+  });
+  return JSON.parse(choices[0].message.content);
+}

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,0 +1,16 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+let OpenAI: any;
+try {
+  OpenAI = require('openai').default;
+} catch {
+  OpenAI = class {
+    chat = { completions: { create: async () => { throw new Error('OpenAI SDK not installed'); } } };
+  };
+}
+
+export const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});

--- a/supabase/migrations/20250925120000_add_ai_training_entries.sql
+++ b/supabase/migrations/20250925120000_add_ai_training_entries.sql
@@ -1,0 +1,14 @@
+-- AI training entries for journal suggestion model
+create table if not exists ai_training_entries (
+  id bigserial primary key,
+  vatCode text,
+  accountDebit text,
+  accountCredit text,
+  amount numeric,
+  description text
+);
+
+-- seed with a couple of examples
+insert into ai_training_entries (vatCode, accountDebit, accountCredit, amount, description) values
+  ('VAT20', '601', '44566', 120.50, 'Office supplies purchase'),
+  ('VAT0', '512', '706', 2000, 'Bank interest');

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -16,7 +16,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- add OpenAI client and AI journal entry generator
- provide prompt template and training data migration
- configure `@` path alias for new modules

## Testing
- `npx vitest run` *(hangs after partial execution)*
- `npm run lint` *(fails: React Hooks must be called in the exact same order)*
- `npm install` *(fails: 403 Forbidden fetching openai)*

------
https://chatgpt.com/codex/tasks/task_e_68919921f4bc8325821efd0a6815bf29