### PR TITLE
feat: add AI entry validation queue

### DIFF
--- a/src/__tests__/aiEntryQueue.test.ts
+++ b/src/__tests__/aiEntryQueue.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { determineStatus } from '../lib/aiEntryQueue';
+
+describe('AI entry status', () => {
+  it('auto-posts with high confidence and low amount', () => {
+    expect(determineStatus(0.95, 1000)).toBe('auto_posted');
+  });
+
+  it('requires review for mid confidence', () => {
+    expect(determineStatus(0.8, 1000)).toBe('needs_review');
+  });
+
+  it('requires review for high amount even with high confidence', () => {
+    expect(determineStatus(0.95, 5000)).toBe('needs_review');
+  });
+
+  it('rejects when confidence is low', () => {
+    expect(determineStatus(0.7, 1000)).toBe('rejected');
+  });
+});

--- a/src/lib/aiEntryQueue.ts
+++ b/src/lib/aiEntryQueue.ts
@@ -1,0 +1,32 @@
+import { supabase } from './supabase';
+
+export type AiEntryStatus =
+  | 'queued'
+  | 'auto_posted'
+  | 'needs_review'
+  | 'rejected';
+
+export function determineStatus(confidence: number, amount: number): AiEntryStatus {
+  if (confidence < 0.75) return 'rejected';
+  if (confidence >= 0.9 && amount < 5000) return 'auto_posted';
+  return 'needs_review';
+}
+
+export async function processQueue(now = new Date()) {
+  const { data } = await supabase
+    .from('ai_entry_queue')
+    .select('id, confidence, amount')
+    .eq('status', 'queued');
+
+  for (const item of data || []) {
+    const status = determineStatus(item.confidence, item.amount);
+    const update: Record<string, any> = { status };
+    if (status === 'auto_posted') {
+      update.posted_at = now.toISOString();
+    }
+    await supabase
+      .from('ai_entry_queue')
+      .update(update)
+      .eq('id', item.id);
+  }
+}

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -622,6 +622,38 @@ export interface Database {
           is_booked?: boolean
         }
       }
+      ,ai_entry_queue: {
+        Row: {
+          id: string
+          suggestion: Json
+          confidence: number
+          amount: number
+          status: 'queued' | 'auto_posted' | 'needs_review' | 'rejected'
+          posted_at: string | null
+          reviewed_by: string | null
+          reviewed_at: string | null
+        }
+        Insert: {
+          id?: string
+          suggestion: Json
+          confidence: number
+          amount: number
+          status?: 'queued' | 'auto_posted' | 'needs_review' | 'rejected'
+          posted_at?: string | null
+          reviewed_by?: string | null
+          reviewed_at?: string | null
+        }
+        Update: {
+          id?: string
+          suggestion?: Json
+          confidence?: number
+          amount?: number
+          status?: 'queued' | 'auto_posted' | 'needs_review' | 'rejected'
+          posted_at?: string | null
+          reviewed_by?: string | null
+          reviewed_at?: string | null
+        }
+      }
     }
   }
 }

--- a/supabase/migrations/20251001120000_add_ai_entry_queue.sql
+++ b/supabase/migrations/20251001120000_add_ai_entry_queue.sql
@@ -1,0 +1,10 @@
+create table if not exists ai_entry_queue (
+  id uuid primary key default gen_random_uuid(),
+  suggestion jsonb not null,
+  confidence numeric not null,
+  amount numeric not null,
+  status text not null default 'queued' check (status in ('queued','auto_posted','needs_review','rejected')),
+  posted_at timestamptz,
+  reviewed_by uuid,
+  reviewed_at timestamptz
+);


### PR DESCRIPTION
## Summary
- add `ai_entry_queue` table to store AI suggestions with confidence and review metadata
- implement status evaluation and queue processor for auto-posting or review
- cover status thresholds with unit tests

## Testing
- `npx vitest run src/__tests__/aiEntryQueue.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68919d9b2acc8325a30a84af057b6b63