### PR TITLE
feat: automate adaptive invoice follow-ups

### DIFF
--- a/database/seed.sql
+++ b/database/seed.sql
@@ -1,3 +1,8 @@
 insert into feature_flags (id, is_enabled)
 values ('onboardingQR', false)
 on conflict (id) do nothing;
+
+insert into relance_profiles (name, tone, min_days_late, max_days_late, payment_score_min) values
+  ('Courtois', 'courtois', 1, 14, 80),
+  ('Ferme', 'ferme', 15, 45, 40),
+  ('Humoristique', 'humoristique', 1, 30, 90);

--- a/prompts/invoice_followup_prompt.txt
+++ b/prompts/invoice_followup_prompt.txt
@@ -1,0 +1,5 @@
+Generate a follow-up message for the following invoice.
+
+invoice: {{invoice}}
+tone: {{tone}}
+styleGuide: "1 paragraphe, 120 mots max, CTA paiement"

--- a/src/__tests__/aiInvoiceFollowup.test.ts
+++ b/src/__tests__/aiInvoiceFollowup.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../lib/openai', () => ({
+  openai: { chat: { completions: { create: vi.fn() } } },
+}));
+vi.mock('../lib/supabase', () => ({ supabase: {} }));
+
+import { buildFollowupPrompt, abTestTone } from '../lib/aiInvoiceFollowup';
+
+describe('invoice follow-up AI helper', () => {
+  it('builds prompt with invoice data and tone', () => {
+    const messages = buildFollowupPrompt(
+      { id: 'inv1', amount: 200, daysLate: 5, historyScore: 95 },
+      'courtois'
+    );
+    const content = messages[1].content;
+    expect(content).toContain('"id":"inv1"');
+    expect(content).toContain('courtois');
+  });
+
+  it('supports A/B tone testing', () => {
+    expect(abTestTone('courtois', 'ferme', 0.3)).toBe('courtois');
+    expect(abTestTone('courtois', 'ferme', 0.7)).toBe('ferme');
+  });
+});

--- a/src/lib/aiInvoiceFollowup.ts
+++ b/src/lib/aiInvoiceFollowup.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { supabase } from './supabase';
+import { openai } from './openai';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const templatePath = path.resolve(__dirname, '../../prompts/invoice_followup_prompt.txt');
+const template = readFileSync(templatePath, 'utf-8');
+
+export type Tone = 'courtois' | 'ferme' | 'humoristique';
+
+export interface InvoiceInfo {
+  id: string;
+  amount: number;
+  daysLate: number;
+  historyScore: number;
+}
+
+export interface RelanceProfile {
+  id: string;
+  name: string;
+  tone: Tone;
+  min_days_late: number;
+  max_days_late: number;
+  payment_score_min: number;
+}
+
+export function buildFollowupPrompt(invoice: InvoiceInfo, tone: Tone) {
+  const content = template
+    .replace('{{invoice}}', JSON.stringify(invoice))
+    .replace('{{tone}}', tone);
+
+  return [
+    {
+      role: 'system',
+      content: 'You are an assistant generating invoice follow-up messages.',
+    },
+    {
+      role: 'user',
+      content,
+    },
+  ];
+}
+
+export async function generateFollowup(invoice: InvoiceInfo, tone: Tone) {
+  const { choices } = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    temperature: 0.7,
+    messages: buildFollowupPrompt(invoice, tone),
+  });
+  return choices[0].message.content;
+}
+
+export function abTestTone(base: Tone, variant?: Tone, seed = Math.random()): Tone {
+  if (!variant) return base;
+  return seed < 0.5 ? base : variant;
+}
+
+export async function generateFollowupWithProfile(
+  invoice: InvoiceInfo,
+  options: { testTone?: Tone } = {}
+) {
+  const { data } = await supabase
+    .from('relance_profiles')
+    .select('tone')
+    .lte('min_days_late', invoice.daysLate)
+    .gte('max_days_late', invoice.daysLate)
+    .lte('payment_score_min', invoice.historyScore)
+    .order('min_days_late', { ascending: false })
+    .limit(1);
+
+  const profileTone = (data?.[0]?.tone as Tone) || 'courtois';
+  const tone = abTestTone(profileTone, options.testTone);
+  return generateFollowup(invoice, tone);
+}

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -622,6 +622,35 @@ export interface Database {
           is_booked?: boolean
         }
       }
+      ,relance_profiles: {
+        Row: {
+          id: string
+          name: string
+          tone: Database['public']['Enums']['relance_tone']
+          min_days_late: number
+          max_days_late: number
+          payment_score_min: number
+        }
+        Insert: {
+          id?: string
+          name: string
+          tone: Database['public']['Enums']['relance_tone']
+          min_days_late?: number
+          max_days_late?: number
+          payment_score_min?: number
+        }
+        Update: {
+          id?: string
+          name?: string
+          tone?: Database['public']['Enums']['relance_tone']
+          min_days_late?: number
+          max_days_late?: number
+          payment_score_min?: number
+        }
+      }
+    }
+    Enums: {
+      relance_tone: 'courtois' | 'ferme' | 'humoristique'
     }
   }
 }

--- a/supabase/migrations/20250930120000_add_relance_profiles.sql
+++ b/supabase/migrations/20250930120000_add_relance_profiles.sql
@@ -1,0 +1,16 @@
+-- Relance profiles table for invoice follow-up tone adaptation
+create type relance_tone as enum ('courtois', 'ferme', 'humoristique');
+
+create table if not exists relance_profiles (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  tone relance_tone not null,
+  min_days_late int not null,
+  max_days_late int not null,
+  payment_score_min int not null
+);
+
+alter table relance_profiles enable row level security;
+
+create policy "Allow read access to relance profiles" on relance_profiles
+  for select using (true);


### PR DESCRIPTION
## Summary
- add `relance_profiles` tone model with enum and seed data
- generate adaptive invoice follow-ups and support tone A/B testing
- provide prompt template and unit tests for follow-up tone selection

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6891a0d8375c8325ba85a0d24bfb991b