### PR TITLE
[CFO C2] Add what-if scenario API and model

### DIFF
--- a/api/cfo/whatif.ts
+++ b/api/cfo/whatif.ts
@@ -1,0 +1,37 @@
+import { FastifyPluginAsync } from 'fastify';
+import { predictCash } from '../../src/lib/cashPredictor';
+import { applyScenario, ScenarioParams, ForecastMonth } from '../../src/lib/whatif';
+
+interface WhatIfBody extends ScenarioParams {
+  accountId: string;
+}
+
+const cache = new Map<string, any>();
+
+const whatIfRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/api/cfo/whatif', async (request, reply) => {
+    const body = request.body as WhatIfBody;
+    const key = JSON.stringify(body);
+    if (cache.has(key)) {
+      const cached = cache.get(key);
+      // refresh LRU order
+      cache.delete(key);
+      cache.set(key, cached);
+      reply.send(cached);
+      return;
+    }
+
+    const baseForecast = (await predictCash(body.accountId)) as ForecastMonth[];
+    const result = applyScenario(baseForecast, body);
+
+    cache.set(key, result);
+    if (cache.size > 10) {
+      const firstKey = cache.keys().next().value;
+      cache.delete(firstKey);
+    }
+
+    reply.send(result);
+  });
+};
+
+export default whatIfRoute;

--- a/src/__tests__/applyScenario.test.ts
+++ b/src/__tests__/applyScenario.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { applyScenario, ForecastMonth } from '../lib/whatif';
+
+describe('applyScenario', () => {
+  const base: ForecastMonth[] = Array.from({ length: 12 }, (_, i) => ({
+    month: `2024-${i + 1}`,
+    revenue: 100,
+    marginPct: 0.4,
+    salaries: 20,
+    opex: 10,
+    startingCash: i === 0 ? 0 : undefined,
+  }));
+
+  it('computes KPI variation', () => {
+    const res = applyScenario(base, { deltaCApct: 10, deltaMarginPct: 0, deltaSalary: 0, deltaOpex: 0 });
+    expect(res.forecast).toHaveLength(12);
+    expect(res.kpiDiff.cash_min).toBeCloseTo(4);
+    expect(res.kpiDiff.solde_fin_annee).toBeCloseTo(48);
+    expect(res.kpiDiff.EBITDA).toBeCloseTo(48);
+  });
+});

--- a/src/__tests__/whatifApi.test.ts
+++ b/src/__tests__/whatifApi.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import Fastify from 'fastify';
+import whatIfRoute from '../../api/cfo/whatif';
+import { ForecastMonth } from '../lib/whatif';
+
+const base: ForecastMonth[] = Array.from({ length: 12 }, (_, i) => ({
+  month: `2024-${i + 1}`,
+  revenue: 100,
+  marginPct: 0.4,
+  salaries: 20,
+  opex: 10,
+  startingCash: i === 0 ? 0 : undefined,
+}));
+
+vi.mock('../../src/lib/cashPredictor', () => ({
+  predictCash: vi.fn(() => new Promise((resolve) => setTimeout(() => resolve(base), 3000)))
+}));
+
+describe('what-if API', () => {
+  it(
+    'caches scenario results to stay under 2s',
+    async () => {
+      vi.useFakeTimers();
+      const app = Fastify();
+      await app.register(whatIfRoute);
+      const payload = { accountId: 'a1', deltaCApct: 10, deltaMarginPct: 0, deltaSalary: 0, deltaOpex: 0 };
+
+      const start = Date.now();
+      const req1 = app.inject({ method: 'POST', url: '/api/cfo/whatif', payload });
+      await vi.advanceTimersByTimeAsync(3000);
+      await vi.runAllTimersAsync();
+      const res1 = await req1;
+      const duration1 = Date.now() - start;
+      expect(res1.statusCode).toBe(200);
+      expect(duration1).toBeGreaterThanOrEqual(3000);
+
+      const start2 = Date.now();
+      const res2Promise = app.inject({ method: 'POST', url: '/api/cfo/whatif', payload });
+      await vi.runAllTimersAsync();
+      const res2 = await res2Promise;
+      const duration2 = Date.now() - start2;
+      expect(duration2).toBeLessThan(2000);
+
+      const body1 = JSON.parse(res1.payload);
+      const body2 = JSON.parse(res2.payload);
+      expect(body2).toEqual(body1);
+
+      const { predictCash } = await import('../../src/lib/cashPredictor');
+      expect((predictCash as any).mock.calls.length).toBe(1);
+
+      await app.close();
+      vi.useRealTimers();
+    },
+    10000
+  );
+});

--- a/src/components/WhatIfPanel.tsx
+++ b/src/components/WhatIfPanel.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+function debounce<F extends (...args: any[]) => void>(fn: F, delay: number) {
+  let timer: ReturnType<typeof setTimeout>;
+  return (...args: Parameters<F>) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+}
+
+interface Props {
+  accountId: string;
+}
+
+export default function WhatIfPanel({ accountId }: Props) {
+  const [deltaCApct, setDeltaCApct] = useState(0);
+  const [deltaMarginPct, setDeltaMarginPct] = useState(0);
+  const [deltaSalary, setDeltaSalary] = useState(0);
+  const [deltaOpex, setDeltaOpex] = useState(0);
+  const [kpi, setKpi] = useState<any>(null);
+
+  const runScenario = useMemo(
+    () =>
+      debounce(async (params: any) => {
+        const res = await fetch('/api/cfo/whatif', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ accountId, ...params }),
+        });
+        const data = await res.json();
+        setKpi(data.kpiDiff);
+      }, 400),
+    [accountId]
+  );
+
+  useEffect(() => {
+    runScenario({ deltaCApct, deltaMarginPct, deltaSalary, deltaOpex });
+  }, [deltaCApct, deltaMarginPct, deltaSalary, deltaOpex, runScenario]);
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <label>CA</label>
+        <input type="range" min="-20" max="50" value={deltaCApct} onChange={(e) => setDeltaCApct(Number(e.target.value))} />
+      </div>
+      <div>
+        <label>Marge</label>
+        <input type="range" min="-10" max="10" value={deltaMarginPct} onChange={(e) => setDeltaMarginPct(Number(e.target.value))} />
+      </div>
+      <div>
+        <label>Salaires</label>
+        <input
+          type="range"
+          min="-100000"
+          max="100000"
+          step="1000"
+          value={deltaSalary}
+          onChange={(e) => setDeltaSalary(Number(e.target.value))}
+        />
+      </div>
+      <div>
+        <label>OPEX</label>
+        <input
+          type="range"
+          min="-100000"
+          max="100000"
+          step="1000"
+          value={deltaOpex}
+          onChange={(e) => setDeltaOpex(Number(e.target.value))}
+        />
+      </div>
+      {kpi && (
+        <div className="text-sm">
+          <div>Min cash: {kpi.cash_min?.toFixed(2)}</div>
+          <div>Solde fin d'année: {kpi.solde_fin_annee?.toFixed(2)}</div>
+          <div>EBITDA: {kpi.EBITDA?.toFixed(2)}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/whatif.ts
+++ b/src/lib/whatif.ts
@@ -1,0 +1,68 @@
+export interface ForecastMonth {
+  month: string;
+  revenue: number; // CA for the month
+  marginPct: number; // margin percentage expressed as 0-1
+  salaries: number; // salary costs for the month
+  opex: number; // operational expenses for the month
+  startingCash?: number; // initial cash for first month
+}
+
+export interface ScenarioParams {
+  deltaCApct: number;
+  deltaMarginPct: number;
+  deltaSalary: number;
+  deltaOpex: number;
+}
+
+interface ForecastResult {
+  month: string;
+  inflow: number;
+  outflow: number;
+  cash: number;
+}
+
+interface KpiDiff {
+  cash_min: number;
+  solde_fin_annee: number;
+  EBITDA: number;
+}
+
+interface ApplyScenarioResult {
+  forecast: ForecastResult[];
+  kpiDiff: KpiDiff;
+}
+
+function computeForecast(base: ForecastMonth[], params: ScenarioParams) {
+  let cash = base[0]?.startingCash ?? 0;
+  let cashMin = cash;
+  let ebitda = 0;
+  const forecast: ForecastResult[] = [];
+
+  for (const m of base) {
+    const revenue = m.revenue * (1 + params.deltaCApct / 100);
+    const marginPct = m.marginPct + params.deltaMarginPct / 100;
+    const inflow = revenue * marginPct;
+    const salaries = m.salaries + params.deltaSalary;
+    const opex = m.opex + params.deltaOpex;
+    const outflow = salaries + opex;
+    cash += inflow - outflow;
+    if (cash < cashMin) cashMin = cash;
+    ebitda += inflow - outflow;
+    forecast.push({ month: m.month, inflow, outflow, cash });
+  }
+
+  return { forecast, cashMin, finalCash: cash, ebitda };
+}
+
+export function applyScenario(baseForecast: ForecastMonth[], params: ScenarioParams): ApplyScenarioResult {
+  const base = computeForecast(baseForecast, { deltaCApct: 0, deltaMarginPct: 0, deltaSalary: 0, deltaOpex: 0 });
+  const scenario = computeForecast(baseForecast, params);
+  return {
+    forecast: scenario.forecast,
+    kpiDiff: {
+      cash_min: scenario.cashMin - base.cashMin,
+      solde_fin_annee: scenario.finalCash - base.finalCash,
+      EBITDA: scenario.ebitda - base.ebitda,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- implement `applyScenario` to recompute cash-flow forecasts and KPI deltas
- expose `/api/cfo/whatif` endpoint with basic LRU caching
- add React `WhatIfPanel` component and supporting unit tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6891bb57dfb48325a9aaebab85fb411d