### PR TITLE
feat: add proactive cash alerts

### DIFF
--- a/emails/templates/cash_alert.mjml
+++ b/emails/templates/cash_alert.mjml
@@ -1,0 +1,11 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text>Votre trésorerie passera sous deux mois de couverture le {{month}} avec un minimum de {{minCash}}€.</mj-text>
+        <mj-text>Actions suggérées : factoring, prêt court terme, relance clients.</mj-text>
+        <mj-button href="https://app.example.com/finance">Voir les options</mj-button>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/src/__tests__/cashAlert.test.ts
+++ b/src/__tests__/cashAlert.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { buildCashAlertJobs } from '../lib/cron/cashAlert';
+
+describe('cash alert job builder', () => {
+  it('builds alert email jobs from candidates', () => {
+    const candidates = [
+      { accountId: 'a1', month_breach: '2024-05-01', min_cash: 1000 }
+    ];
+    const jobs = buildCashAlertJobs(candidates);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].template).toBe('cash_alert');
+    expect(jobs[0].payload.suggestions).toContain('factoring');
+  });
+});

--- a/src/lib/cron/cashAlert.ts
+++ b/src/lib/cron/cashAlert.ts
@@ -1,0 +1,41 @@
+import { supabase } from '../supabase';
+
+export interface CashAlertCandidate {
+  accountId: string;
+  month_breach: string;
+  min_cash: number;
+}
+
+export interface EmailJob {
+  accountId: string;
+  template: string;
+  payload: Record<string, any>;
+}
+
+export function buildCashAlertJobs(candidates: CashAlertCandidate[]): EmailJob[] {
+  return candidates.map((c) => ({
+    accountId: c.accountId,
+    template: 'cash_alert',
+    payload: {
+      month: c.month_breach,
+      minCash: c.min_cash,
+      suggestions: ['factoring', 'prêt court terme', 'relance clients']
+    }
+  }));
+}
+
+export async function enqueueCashAlerts() {
+  const { data } = await supabase
+    .from<CashAlertCandidate>('v_cash_alert_candidates' as any)
+    .select('accountId, month_breach, min_cash');
+  const candidates = data || [];
+  const jobs = buildCashAlertJobs(candidates);
+  for (const job of jobs) {
+    await supabase.from('email_jobs').insert({
+      account_id: job.accountId,
+      template: job.template,
+      payload: job.payload
+    });
+  }
+  return jobs.length;
+}

--- a/supabase/functions/enqueue_cash_alerts.ts
+++ b/supabase/functions/enqueue_cash_alerts.ts
@@ -1,0 +1,25 @@
+import { createClient } from '@supabase/supabase-js';
+import { buildCashAlertJobs } from '../../src/lib/cron/cashAlert.ts';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const supabase = createClient(supabaseUrl, serviceKey);
+
+Deno.serve(async () => {
+  const { data } = await supabase
+    .from('v_cash_alert_candidates')
+    .select('accountId, month_breach, min_cash');
+  const candidates = data || [];
+  const jobs = buildCashAlertJobs(candidates as any);
+  for (const job of jobs) {
+    await supabase.from('email_jobs').insert({
+      account_id: job.accountId,
+      template: job.template,
+      payload: job.payload
+    });
+  }
+  return new Response(
+    JSON.stringify({ inserted: jobs.length }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+});

--- a/supabase/migrations/20251010120000_add_cash_alert_view.sql
+++ b/supabase/migrations/20251010120000_add_cash_alert_view.sql
@@ -1,0 +1,11 @@
+-- View to detect cash alert candidates and schedule alert job
+create or replace view v_cash_alert_candidates as
+select accountId,
+       min(month)   as month_breach,
+       min(balance) as min_cash
+from cash_forecast
+where balance < (monthlyBurn * 2)
+group by accountId;
+
+-- Schedule daily cash alert check at 08:00
+select cron.schedule('daily_cash_alerts', '0 8 * * *', $$select enqueue_cash_alerts();$$);


### PR DESCRIPTION
## Summary
- add SQL view and cron job for cash alert candidates
- send proactive cash alert emails with actionable suggestions
- cover cash alert job builder with unit test and MJML template

## Testing
- `npx vitest run`
- `npx vitest run src/__tests__/cashAlert.test.ts`
- `npm run lint` *(fails: React Hooks must be called in same order)*

------
https://chatgpt.com/codex/tasks/task_e_6891c2ba6fb083258cc072eaf112aeb5