### PR TITLE
[CFO C4] add predictive dashboard scaffolding

### DIFF
--- a/api/cfo/forecast.ts
+++ b/api/cfo/forecast.ts
@@ -1,0 +1,22 @@
+import { FastifyPluginAsync } from 'fastify';
+
+interface ForecastPoint {
+  month: string;
+  forecast: number;
+  actual: number;
+  balance: number;
+}
+
+const forecastRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/api/cfo/forecast', async (_request, reply) => {
+    const data: ForecastPoint[] = Array.from({ length: 12 }, (_, i) => ({
+      month: `M${i + 1}`,
+      forecast: Math.round(Math.random() * 10000),
+      actual: Math.round(Math.random() * 10000),
+      balance: Math.round(Math.random() * 10000)
+    }));
+    reply.send(data);
+  });
+};
+
+export default forecastRoute;

--- a/api/cfo/pnl.ts
+++ b/api/cfo/pnl.ts
@@ -1,0 +1,33 @@
+import { FastifyPluginAsync } from 'fastify';
+
+interface PnlMonth {
+  month: string;
+  revenue: number;
+  costs: number;
+  ebitda: number;
+}
+
+const cache = new Map<string, { data: PnlMonth[]; expires: number }>();
+
+const pnlRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/api/cfo/pnl', async (request, reply) => {
+    const months = Number((request.query as any).months) || 12;
+    const key = String(months);
+    const now = Date.now();
+    const cached = cache.get(key);
+    if (cached && cached.expires > now) {
+      return reply.send(cached.data);
+    }
+
+    const data: PnlMonth[] = Array.from({ length: months }, (_, i) => ({
+      month: `M${i + 1}`,
+      revenue: Math.round(Math.random() * 10000 + 20000),
+      costs: Math.round(Math.random() * 8000 + 10000),
+      ebitda: Math.round(Math.random() * 5000)
+    }));
+    cache.set(key, { data, expires: now + 5 * 60 * 1000 });
+    reply.send(data);
+  });
+};
+
+export default pnlRoute;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,12 +28,23 @@ import KpiQrPage from './pages/admin/kpi-qr';
 import { useFeatureFlag } from './lib/hooks/useFeatureFlag';
 import { Navigate } from 'react-router-dom';
 import './styles/globals.css';
+import CfoDashboard from './pages/CfoDashboard';
+import { useAuthContext } from './contexts/AuthContext';
 
 const QrUploadRoute: React.FC = () => {
   const { enabled, loading } = useFeatureFlag('onboardingQR');
   if (loading) return <p>Chargement...</p>;
   if (!enabled) return <Navigate to="/onboarding/tax" />;
   return <QrUploadPage />;
+};
+
+const CfoDashboardRoute: React.FC = () => {
+  const { enabled, loading } = useFeatureFlag('cfoDashboardV1');
+  const { user, loading: authLoading } = useAuthContext();
+  const role = (user?.user_metadata as any)?.role;
+  if (loading || authLoading) return <p>Chargement...</p>;
+  if (!enabled || (role !== 'cfo' && role !== 'admin')) return <Navigate to="/" />;
+  return <CfoDashboard />;
 };
 
 const App: React.FC = () => (
@@ -76,6 +87,7 @@ const App: React.FC = () => (
             <Route path="/qr-upload/:sessionToken" element={<QrUploadRoute />} />
             <Route path="/admin/feature-flags" element={<Layout><FeatureFlagsPage /></Layout>} />
             <Route path="/admin/kpi-qr" element={<Layout><KpiQrPage /></Layout>} />
+            <Route path="/cfo/dashboard" element={<Layout><CfoDashboardRoute /></Layout>} />
           </Routes>
         </AuthProvider>
       </ToastProvider>

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -13,6 +13,12 @@ vi.mock('../contexts/AuthContext', () => {
   };
 });
 
+vi.mock('../lib/hooks/useFeatureFlag', () => {
+  return {
+    useFeatureFlag: () => ({ enabled: false, loading: false, error: null })
+  };
+});
+
 describe('<App />', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');

--- a/src/__tests__/KpiChip.test.tsx
+++ b/src/__tests__/KpiChip.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import KpiChip from '../components/KpiChip';
+
+describe('KpiChip', () => {
+  it('renders label and value', () => {
+    render(<KpiChip label="Test KPI" value="42" />);
+    expect(screen.getByText('Test KPI')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+});

--- a/src/components/KpiChip.tsx
+++ b/src/components/KpiChip.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface KpiChipProps {
+  label: string;
+  value: React.ReactNode;
+}
+
+const KpiChip: React.FC<KpiChipProps> = ({ label, value }) => (
+  <div className="px-3 py-2 bg-white rounded shadow text-center" role="status" aria-label={label}>
+    <div className="text-xs text-gray-500">{label}</div>
+    <div className="font-bold">{value}</div>
+  </div>
+);
+
+export default KpiChip;

--- a/src/components/cfo/AlertsPanel.tsx
+++ b/src/components/cfo/AlertsPanel.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Alert from '../ui/Alert';
+
+export interface AlertItem {
+  id: string | number;
+  message: string;
+  variant?: 'info' | 'success' | 'warning' | 'error';
+}
+
+interface Props {
+  alerts: AlertItem[];
+}
+
+const AlertsPanel: React.FC<Props> = ({ alerts }) => (
+  <div className="space-y-2 overflow-y-auto max-h-64" aria-label="Alerts list">
+    {alerts.length === 0 ? (
+      <p className="text-sm text-gray-500">Aucune alerte</p>
+    ) : (
+      alerts.map((a) => (
+        <Alert key={a.id} variant={a.variant}>{a.message}</Alert>
+      ))
+    )}
+  </div>
+);
+
+export default AlertsPanel;

--- a/src/components/cfo/CashFlowChart.tsx
+++ b/src/components/cfo/CashFlowChart.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip
+} from 'recharts';
+
+export interface CashFlowPoint {
+  month: string;
+  forecast: number;
+  actual: number;
+  balance: number;
+}
+
+interface Props {
+  data: CashFlowPoint[];
+}
+
+const CashFlowChart: React.FC<Props> = ({ data }) => (
+  <ResponsiveContainer width="100%" aspect={4 / 3}>
+    <AreaChart data={data} aria-label="Cash flow chart">
+      <XAxis dataKey="month" />
+      <YAxis />
+      <Tooltip />
+      <Area type="monotone" dataKey="forecast" stackId="1" stroke="#8884d8" fill="#8884d8" />
+      <Area type="monotone" dataKey="actual" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
+      <Line type="monotone" dataKey="balance" stroke="#000" dot={false} />
+    </AreaChart>
+  </ResponsiveContainer>
+);
+
+export default CashFlowChart;

--- a/src/components/cfo/PnlChart.tsx
+++ b/src/components/cfo/PnlChart.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend
+} from 'recharts';
+
+export interface PnlPoint {
+  month: string;
+  revenue: number;
+  costs: number;
+  ebitda: number;
+}
+
+interface Props {
+  data: PnlPoint[];
+}
+
+const PnlChart: React.FC<Props> = ({ data }) => (
+  <ResponsiveContainer width="100%" aspect={4 / 3}>
+    <ComposedChart data={data} aria-label="P&L chart">
+      <XAxis dataKey="month" />
+      <YAxis />
+      <Tooltip />
+      <Legend />
+      <Bar dataKey="revenue" fill="#4f46e5" name="CA" />
+      <Bar dataKey="costs" fill="#f87171" name="Coûts" />
+      <Line type="monotone" dataKey="ebitda" stroke="#10b981" name="EBITDA" />
+    </ComposedChart>
+  </ResponsiveContainer>
+);
+
+export default PnlChart;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -16,6 +16,8 @@ import {
   ChevronLeft,
   ChevronRight
 } from 'lucide-react';
+import { useFeatureFlag } from '../../lib/hooks/useFeatureFlag';
+import { useAuthContext } from '../../contexts/AuthContext';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -23,6 +25,10 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, toggle }) => {
+  const { enabled: cfoEnabled } = useFeatureFlag('cfoDashboardV1');
+  const { user } = useAuthContext();
+  const role = (user?.user_metadata as any)?.role;
+
   const navItems = [
     { name: 'Mon Entreprise', icon: <Home size={20} />, path: '/' },
     { name: 'Clôture & Pilotage', icon: <CalendarClock size={20} />, path: '/closing' },
@@ -37,6 +43,10 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, toggle }) => {
     { name: 'Mon Expert', icon: <UserCog size={20} />, path: '/expert' },
     { name: 'Centre de Connaissances', icon: <BookOpen size={20} />, path: '/knowledge' }
   ];
+
+  if (cfoEnabled && (role === 'cfo' || role === 'admin')) {
+    navItems.push({ name: 'Dashboard prédictif', icon: <BarChart3 size={20} />, path: '/cfo/dashboard' });
+  }
 
   return (
     <aside className={`sidebar ${isOpen ? 'translate-x-0' : '-translate-x-64 md:translate-x-0'}`}>

--- a/src/pages/CfoDashboard.tsx
+++ b/src/pages/CfoDashboard.tsx
@@ -1,0 +1,66 @@
+import React, { lazy, Suspense, useEffect, useState } from 'react';
+import KpiChip from '../components/KpiChip';
+import { CashFlowPoint } from '../components/cfo/CashFlowChart';
+import { PnlPoint } from '../components/cfo/PnlChart';
+import { AlertItem } from '../components/cfo/AlertsPanel';
+
+const CashFlowChart = lazy(() => import('../components/cfo/CashFlowChart'));
+const PnlChart = lazy(() => import('../components/cfo/PnlChart'));
+const AlertsPanel = lazy(() => import('../components/cfo/AlertsPanel'));
+const WhatIfPanel = lazy(() => import('../components/WhatIfPanel'));
+
+const CfoDashboard: React.FC = () => {
+  const [cashData, setCashData] = useState<CashFlowPoint[]>([]);
+  const [pnlData, setPnlData] = useState<PnlPoint[]>([]);
+  const [alerts, setAlerts] = useState<AlertItem[]>([]);
+  const [showWhatIf, setShowWhatIf] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/cfo/forecast')
+      .then((r) => r.json())
+      .then(setCashData)
+      .catch(() => {});
+    fetch('/api/cfo/pnl?months=12')
+      .then((r) => r.json())
+      .then(setPnlData)
+      .catch(() => {});
+    // placeholder alerts
+    setAlerts([]);
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4">
+      <header className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        <KpiChip label="Cash min" value="--" />
+        <KpiChip label="Burn" value="--" />
+        <KpiChip label="EBITDA %" value="--" />
+        <KpiChip label="DSO" value="--" />
+      </header>
+      <div className="grid md:grid-cols-2 gap-4">
+        <Suspense fallback={<div>Loading...</div>}>
+          <CashFlowChart data={cashData} />
+        </Suspense>
+        <Suspense fallback={<div>Loading...</div>}>
+          <PnlChart data={pnlData} />
+        </Suspense>
+        <Suspense fallback={<div>Loading...</div>}>
+          {showWhatIf ? (
+            <WhatIfPanel accountId="" />
+          ) : (
+            <button
+              onClick={() => setShowWhatIf(true)}
+              className="btn btn-primary w-full md:w-auto"
+            >
+              Ouvrir What-if
+            </button>
+          )}
+        </Suspense>
+        <Suspense fallback={<div>Loading...</div>}>
+          <AlertsPanel alerts={alerts} />
+        </Suspense>
+      </div>
+    </div>
+  );
+};
+
+export default CfoDashboard;


### PR DESCRIPTION
## Summary
- set up CFO dashboard route with feature flag & role guard
- add KPI chip, cash-flow & P&L charts, alerts panel
- expose mock P&L and forecast APIs

## Testing
- `npx vitest run src/__tests__/KpiChip.test.tsx`
- `npm run lint` *(fails: React Hooks must be called in the exact same order)*

------
https://chatgpt.com/codex/tasks/task_e_6891c73439908325b609f601edc28d87