### PR TITLE
feat: add slack sync alert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ VITE_SIRENE_API_TOKEN=your-sirene-token
 VITE_ONBOARDING_V2=true
 NEXT_PUBLIC_OCR_ENDPOINT=https://api.example.com
 
+SLACK_SYNC_WEBHOOK=https://hooks.slack.com/services/your-webhook

--- a/src/__tests__/slackSyncAlert.test.ts
+++ b/src/__tests__/slackSyncAlert.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { slackSyncAlert } from '../lib/slackSyncAlert';
+
+describe('slackSyncAlert', () => {
+  it('sends message to slack webhook', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true })) as any;
+    vi.stubGlobal('fetch', fetchMock);
+    process.env.SLACK_SYNC_WEBHOOK = 'https://example.com';
+
+    await slackSyncAlert('test message');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'test message' })
+    });
+  });
+});

--- a/src/lib/slackSyncAlert.ts
+++ b/src/lib/slackSyncAlert.ts
@@ -1,0 +1,7 @@
+export async function slackSyncAlert(message: string) {
+  await fetch(process.env.SLACK_SYNC_WEBHOOK, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: message })
+  });
+}


### PR DESCRIPTION
## Summary
- add slackSyncAlert util for posting messages to Slack
- document SLACK_SYNC_WEBHOOK in env example
- test slackSyncAlert behavior

## Testing
- `npm test -- --run src/__tests__/slackSyncAlert.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6891ed4bfe548325bbdad273d483de96