### PR TITLE
feat: add Abacus entries fetcher and test

### DIFF
--- a/src/__tests__/fetchAbacusEntries.test.ts
+++ b/src/__tests__/fetchAbacusEntries.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchAbacusEntries } from '../sync/fetchAbacusEntries';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchAbacusEntries', () => {
+  it('maps Abacus response', async () => {
+    const mockResponse = { data: [{ GLAccount: '7000', amount: 5 }] };
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => mockResponse
+    })) as any);
+
+    const data = await fetchAbacusEntries('acc1', '2024-05-01', '2024-05-02');
+    expect(data[0]).toHaveProperty('glAccount', '7000');
+  });
+});

--- a/src/sync/fetchAbacusEntries.ts
+++ b/src/sync/fetchAbacusEntries.ts
@@ -1,0 +1,20 @@
+export interface AbacusEntry {
+  glAccount: string;
+  [key: string]: unknown;
+}
+
+export async function fetchAbacusEntries(
+  accountId: string,
+  startDate: string,
+  endDate: string
+): Promise<AbacusEntry[]> {
+  const url = `/abacus/${accountId}/entries?start=${startDate}&end=${endDate}`;
+  const res = await fetch(url);
+  const json = await res.json();
+  const entries = Array.isArray(json.data) ? json.data : [];
+
+  return entries.map((entry: any) => ({
+    ...entry,
+    glAccount: entry.GLAccount ?? entry.glAccount
+  }));
+}


### PR DESCRIPTION
## Summary
- add fetchAbacusEntries helper to map Abacus response GLAccount to glAccount
- cover mapping logic with unit test

## Testing
- `npm test src/__tests__/fetchAbacusEntries.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6891ed587f308325aad63cb1a899c888