### PR TITLE
feat: add tick closing tasks function

### DIFF
--- a/supabase/migrations/20251020120000_add_tick_closing_tasks_function.sql
+++ b/supabase/migrations/20251020120000_add_tick_closing_tasks_function.sql
@@ -1,0 +1,16 @@
+-- Function to mark a closing task as done
+create or replace function tick_closing_tasks(
+  p_account uuid,
+  p_period date,
+  p_code text
+) returns void as $$
+begin
+  update closing_tasks
+  set status = 'done', updated_at = now()
+  where account_id = p_account
+    and period = p_period
+    and template_id = (
+      select id from closing_task_templates where code = p_code
+    );
+end;
+$$ language plpgsql;


### PR DESCRIPTION
## Summary
- add tick_closing_tasks function to mark closing tasks done

## Testing
- `npm test` *(fails: expected +0 to be close to 4; worker out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6891ed3401148325ac2c98ae77ea9079