### PR TITLE
feat(closing): add SWR hook and task test

### DIFF
--- a/cypress/e2e/closingTasks.cy.ts
+++ b/cypress/e2e/closingTasks.cy.ts
@@ -1,0 +1,22 @@
+describe('Closing tasks checklist', () => {
+  it('allows validating a task', () => {
+    cy.intercept('GET', '/api/closing/tasks*', {
+      statusCode: 200,
+      body: [
+        {
+          id: 'bank',
+          title: 'Rapprochement bancaire',
+          description: 'Le rapprochement bancaire a été effectué.',
+          status: 'pending'
+        }
+      ]
+    }).as('tasks');
+
+    cy.visit('/closing/monthly');
+    cy.wait('@tasks');
+    cy.contains('Rapprochement bancaire').should('be.visible');
+    cy.contains('Valider').click();
+    cy.contains('Complété').should('be.visible');
+  });
+});
+

--- a/src/lib/hooks/useClosingTasks.ts
+++ b/src/lib/hooks/useClosingTasks.ts
@@ -1,0 +1,19 @@
+import useSWR from '../useSWR';
+
+interface ClosingTask {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  documents?: { name: string; date: string }[];
+}
+
+export function useClosingTasks(accountId: string, period: string) {
+  return useSWR<ClosingTask[]>(
+    `/api/closing/tasks?accountId=${accountId}&period=${period}`,
+    () =>
+      fetch(`/api/closing/tasks?accountId=${accountId}&period=${period}`)
+        .then((r) => r.json()),
+  );
+}
+

--- a/src/pages/MonthlyClosing.tsx
+++ b/src/pages/MonthlyClosing.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import ProgressSteps from '../components/ui/ProgressSteps';
-import { 
+import {
   CheckCircle, 
   FileCheck, 
   AlertTriangle, 
@@ -15,6 +15,8 @@ import {
   UserCog,
   Loader
 } from 'lucide-react';
+import { useToast } from '../contexts/ToastContext';
+import { useClosingTasks } from '../lib/hooks/useClosingTasks';
 
 // Define the steps for the monthly closing process
 const closingSteps = [
@@ -36,6 +38,9 @@ const MonthlyClosing: React.FC = () => {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(2);
   const [loading, setLoading] = useState(false);
+  const { addToast } = useToast();
+
+  const { data: fetchedTasks } = useClosingTasks('demo', '2023-06');
   
   // Sample tasks for the monthly closing checklist
   const [tasks, setTasks] = useState<Task[]>([
@@ -80,10 +85,17 @@ const MonthlyClosing: React.FC = () => {
     }
   ]);
 
+  useEffect(() => {
+    if (fetchedTasks) {
+      setTasks(fetchedTasks as Task[]);
+    }
+  }, [fetchedTasks]);
+
   const updateTaskStatus = (taskId: string, newStatus: Task['status']) => {
-    setTasks(tasks.map(task => 
+    setTasks(tasks.map(task =>
       task.id === taskId ? { ...task, status: newStatus } : task
     ));
+    addToast('Statut de la tâche mis à jour', 'success');
   };
 
   const getTaskStatusIcon = (status: Task['status']) => {


### PR DESCRIPTION
## Summary
- add `useClosingTasks` SWR hook
- wire monthly closing page to toast on task status update
- add Cypress spec for closing tasks

## Testing
- `npm test`
- `npx cypress run --spec cypress/e2e/closingTasks.cy.ts` *(fails: Install Xvfb and run Cypress again)*
- `npm run lint` *(fails: React Hook "useState" is called conditionally)*

------
https://chatgpt.com/codex/tasks/task_e_689217400c548325ad28018e3ef1f476