### PR TITLE
Handle loading and error states for monthly closing tasks

### DIFF
--- a/src/lib/hooks/useClosingTasks.ts
+++ b/src/lib/hooks/useClosingTasks.ts
@@ -9,11 +9,13 @@ interface ClosingTask {
 }
 
 export function useClosingTasks(accountId: string, period: string) {
-  return useSWR<ClosingTask[]>(
+  const { data, error, isLoading, mutate } = useSWR<ClosingTask[]>(
     `/api/closing/tasks?accountId=${accountId}&period=${period}`,
     () =>
       fetch(`/api/closing/tasks?accountId=${accountId}&period=${period}`)
         .then((r) => r.json()),
   );
+
+  return { data, error, isLoading, mutate } as const;
 }
 

--- a/src/lib/useSWR.ts
+++ b/src/lib/useSWR.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 
 interface Options {
   refreshInterval?: number;
@@ -7,26 +7,33 @@ interface Options {
 export default function useSWR<T>(key: string, fetcher: () => Promise<T>, options?: Options) {
   const [data, setData] = useState<T | undefined>();
   const [error, setError] = useState<any>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const active = useRef(true);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await fetcher();
+      if (active.current) setData(result);
+    } catch (err) {
+      if (active.current) setError(err);
+    } finally {
+      if (active.current) setIsLoading(false);
+    }
+  }, [fetcher]);
 
   useEffect(() => {
-    let active = true;
-    const load = async () => {
-      try {
-        const result = await fetcher();
-        if (active) setData(result);
-      } catch (err) {
-        if (active) setError(err);
-      }
-    };
+    active.current = true;
     load();
     const interval = options?.refreshInterval
       ? setInterval(load, options.refreshInterval)
       : null;
     return () => {
-      active = false;
+      active.current = false;
       if (interval) clearInterval(interval);
     };
-  }, [key]);
+  }, [key, load, options?.refreshInterval]);
 
-  return { data, error } as const;
+  return { data, error, isLoading, mutate: load } as const;
 }

--- a/src/pages/MonthlyClosing.tsx
+++ b/src/pages/MonthlyClosing.tsx
@@ -40,10 +40,12 @@ const MonthlyClosing: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const { addToast } = useToast();
 
-  const { data: fetchedTasks, isLoading, error, mutate } = useClosingTasks('demo', '2023-06');
-  
+  const accountId = 'demo';
+  const period = '2023-06';
+  const { data: tasks, isLoading, error, mutate } = useClosingTasks(accountId, period);
+
   // Sample tasks for the monthly closing checklist
-  const [tasks, setTasks] = useState<Task[]>([
+  const [taskList, setTaskList] = useState<Task[]>([
     {
       id: 'invoices',
       title: 'Factures clients',
@@ -86,10 +88,10 @@ const MonthlyClosing: React.FC = () => {
   ]);
 
   useEffect(() => {
-    if (fetchedTasks) {
-      setTasks(fetchedTasks as Task[]);
+    if (tasks) {
+      setTaskList(tasks as Task[]);
     }
-  }, [fetchedTasks]);
+  }, [tasks]);
 
   if (isLoading) {
     return (
@@ -109,7 +111,7 @@ const MonthlyClosing: React.FC = () => {
   }
 
   const updateTaskStatus = (taskId: string, newStatus: Task['status']) => {
-    setTasks(tasks.map(task =>
+    setTaskList(taskList.map(task =>
       task.id === taskId ? { ...task, status: newStatus } : task
     ));
     addToast('Statut de la tâche mis à jour', 'success');
@@ -222,7 +224,7 @@ const MonthlyClosing: React.FC = () => {
             </p>
             
             <div className="space-y-4">
-              {tasks.map((task) => (
+              {taskList.map((task) => (
                 <div 
                   key={task.id}
                   className={`border rounded-lg p-4 ${
@@ -300,7 +302,7 @@ const MonthlyClosing: React.FC = () => {
               icon={loading ? <Loader size={16} className="animate-spin" /> : <ChevronRight size={16} />}
               iconPosition="right"
               onClick={handleNextStep}
-              disabled={loading || tasks.some(task => task.status === 'missing')}
+              disabled={loading || taskList.some(task => task.status === 'missing')}
             >
               {loading ? 'Traitement en cours...' : 'Continuer'}
             </Button>

--- a/src/pages/MonthlyClosing.tsx
+++ b/src/pages/MonthlyClosing.tsx
@@ -40,7 +40,7 @@ const MonthlyClosing: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const { addToast } = useToast();
 
-  const { data: fetchedTasks } = useClosingTasks('demo', '2023-06');
+  const { data: fetchedTasks, isLoading, error, mutate } = useClosingTasks('demo', '2023-06');
   
   // Sample tasks for the monthly closing checklist
   const [tasks, setTasks] = useState<Task[]>([
@@ -90,6 +90,23 @@ const MonthlyClosing: React.FC = () => {
       setTasks(fetchedTasks as Task[]);
     }
   }, [fetchedTasks]);
+
+  if (isLoading) {
+    return (
+      <div className="animate-slide-in-up flex justify-center py-8">
+        <Loader className="animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="animate-slide-in-up text-center py-8">
+        <p className="text-error mb-4">Erreur lors du chargement des tâches.</p>
+        <Button variant="primary" onClick={() => mutate()}>Réessayer</Button>
+      </div>
+    );
+  }
 
   const updateTaskStatus = (taskId: string, newStatus: Task['status']) => {
     setTasks(tasks.map(task =>


### PR DESCRIPTION
## Summary
- Expose loading state and retry support in custom `useSWR`
- Extend `useClosingTasks` to return `isLoading` and `error`
- Show loader and retryable error message in `MonthlyClosing`

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68925043839083258023bc838b2d8baf