### PR TITLE
chore: add aria labels to icon buttons

### DIFF
--- a/src/components/clients/InvoiceTable.tsx
+++ b/src/components/clients/InvoiceTable.tsx
@@ -109,7 +109,10 @@ const InvoiceTable: React.FC = () => {
                       {(invoice.total ?? 0).toLocaleString()} €
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
-                      <button className="text-gray-400 hover:text-gray-500">
+                      <button
+                        className="text-gray-400 hover:text-gray-500"
+                        aria-label="Afficher les options"
+                      >
                         <MoreVertical size={16} />
                       </button>
                     </td>

--- a/src/components/ui/FilterBar.tsx
+++ b/src/components/ui/FilterBar.tsx
@@ -181,6 +181,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
                 <button
                   className="ml-2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                   onClick={() => handleFilterChange(key, null)}
+                  aria-label="Retirer le filtre"
                 >
                   <X size={14} />
                 </button>

--- a/src/components/ui/MaxAssistant.tsx
+++ b/src/components/ui/MaxAssistant.tsx
@@ -132,6 +132,7 @@ const MaxAssistant: React.FC = () => {
           ref={openButtonRef}
           onClick={() => setIsOpen(true)}
           className="fixed bottom-6 right-6 bg-primary text-white rounded-full p-4 shadow-lg hover:bg-primary-light transition-all duration-300 z-50 group animate-bounce hover:animate-none"
+          aria-label="Ouvrir l'assistant Max"
         >
           <div className="absolute -top-2 -right-2 w-4 h-4 bg-accent rounded-full animate-ping"></div>
           <div className="absolute -top-2 -right-2 w-4 h-4 bg-accent rounded-full"></div>
@@ -170,12 +171,14 @@ const MaxAssistant: React.FC = () => {
             <button
               onClick={() => setIsExpanded(!isExpanded)}
               className="p-2 hover:bg-white/10 rounded-full transition-colors"
+              aria-label={isExpanded ? 'Réduire la fenêtre' : 'Agrandir la fenêtre'}
             >
               {isExpanded ? <Minimize2 size={20} /> : <Maximize2 size={20} />}
             </button>
             <button
               onClick={() => setIsOpen(false)}
               className="p-2 hover:bg-white/10 rounded-full transition-colors"
+              aria-label="Fermer l'assistant"
             >
               <X size={20} />
             </button>

--- a/src/components/ui/ProgressSteps.tsx
+++ b/src/components/ui/ProgressSteps.tsx
@@ -29,6 +29,7 @@ const ProgressSteps: React.FC<ProgressStepsProps> = ({
               className={`progress-step-number ${
                 currentStep === step.id ? 'active' : ''
               } ${step.completed ? 'completed' : ''}`}
+              aria-label={`Étape ${index + 1} : ${step.label}`}
             >
               {step.completed ? (
                 <Check size={16} />

--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -114,8 +114,18 @@ const Assets: React.FC = () => {
       header: 'Actions',
       accessor: (row: any) => (
         <div className="flex justify-end space-x-2">
-          <Button variant="text" size="sm" icon={<Edit size={16} />} />
-          <Button variant="text" size="sm" icon={<Trash2 size={16} />} />
+          <Button
+            variant="text"
+            size="sm"
+            icon={<Edit size={16} />}
+            ariaLabel="Modifier l'actif"
+          />
+          <Button
+            variant="text"
+            size="sm"
+            icon={<Trash2 size={16} />}
+            ariaLabel="Supprimer l'actif"
+          />
         </div>
       ),
       align: 'right'

--- a/src/pages/Closing.tsx
+++ b/src/pages/Closing.tsx
@@ -245,13 +245,22 @@ const Closing: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end space-x-2">
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir le rapport"
+                      >
                         <FileText size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Télécharger le rapport"
+                      >
                         <Download size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir l'analyse"
+                      >
                         <BarChart size={16} />
                       </button>
                     </div>
@@ -278,13 +287,22 @@ const Closing: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end space-x-2">
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir le rapport"
+                      >
                         <FileText size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Télécharger le rapport"
+                      >
                         <Download size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir l'analyse"
+                      >
                         <BarChart size={16} />
                       </button>
                     </div>

--- a/src/pages/Documents.tsx
+++ b/src/pages/Documents.tsx
@@ -96,10 +96,20 @@ const Documents: React.FC = () => {
       header: 'Actions',
       accessor: (row: any) => (
         <div className="flex justify-end space-x-2">
-          <Button variant="text" size="sm" icon={<Download size={16} />} />
+          <Button
+            variant="text"
+            size="sm"
+            icon={<Download size={16} />}
+            ariaLabel="Télécharger"
+          />
           <Dropdown
             trigger={
-              <Button variant="text" size="sm" icon={<MoreVertical size={16} />} />
+              <Button
+                variant="text"
+                size="sm"
+                icon={<MoreVertical size={16} />}
+                ariaLabel="Options"
+              />
             }
             items={[
               { label: 'Télécharger', value: 'download', icon: <Download size={16} /> },

--- a/src/pages/Salaries.tsx
+++ b/src/pages/Salaries.tsx
@@ -181,10 +181,16 @@ const Salaries: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end space-x-2">
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir le document"
+                      >
                         <FileText size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Télécharger le document"
+                      >
                         <Download size={16} />
                       </button>
                     </div>
@@ -214,10 +220,16 @@ const Salaries: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end space-x-2">
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir le document"
+                      >
                         <FileText size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Télécharger le document"
+                      >
                         <Download size={16} />
                       </button>
                     </div>
@@ -247,10 +259,16 @@ const Salaries: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end space-x-2">
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir le document"
+                      >
                         <FileText size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Télécharger le document"
+                      >
                         <Download size={16} />
                       </button>
                     </div>
@@ -280,10 +298,16 @@ const Salaries: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end space-x-2">
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir le document"
+                      >
                         <FileText size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Télécharger le document"
+                      >
                         <Download size={16} />
                       </button>
                     </div>
@@ -343,10 +367,16 @@ const Salaries: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end space-x-2">
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir le document"
+                      >
                         <FileText size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Télécharger le document"
+                      >
                         <Download size={16} />
                       </button>
                     </div>
@@ -368,10 +398,16 @@ const Salaries: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end space-x-2">
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir le document"
+                      >
                         <FileText size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Télécharger le document"
+                      >
                         <Download size={16} />
                       </button>
                     </div>
@@ -393,10 +429,16 @@ const Salaries: React.FC = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end space-x-2">
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Voir le document"
+                      >
                         <FileText size={16} />
                       </button>
-                      <button className="text-primary hover:text-primary-light">
+                      <button
+                        className="text-primary hover:text-primary-light"
+                        aria-label="Télécharger le document"
+                      >
                         <Download size={16} />
                       </button>
                     </div>

--- a/src/pages/SalaryManagement.tsx
+++ b/src/pages/SalaryManagement.tsx
@@ -236,7 +236,10 @@ const SalaryManagement: React.FC = () => {
                         {employee.salary.toLocaleString()} €
                       </td>
                       <td className="px-4 py-4 whitespace-nowrap text-right text-sm font-medium">
-                        <button className="text-primary hover:text-primary-light mr-3">
+                        <button
+                          className="text-primary hover:text-primary-light mr-3"
+                          aria-label="Modifier le salarié"
+                        >
                           <Edit size={16} />
                         </button>
                       </td>

--- a/src/pages/Suppliers.tsx
+++ b/src/pages/Suppliers.tsx
@@ -173,7 +173,10 @@ const Suppliers: React.FC = () => {
                     1 250 €
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
-                    <button className="text-gray-400 hover:text-gray-500">
+                    <button
+                      className="text-gray-400 hover:text-gray-500"
+                      aria-label="Afficher les options"
+                    >
                       <MoreVertical size={16} />
                     </button>
                   </td>
@@ -203,7 +206,10 @@ const Suppliers: React.FC = () => {
                     3 780 €
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
-                    <button className="text-gray-400 hover:text-gray-500">
+                    <button
+                      className="text-gray-400 hover:text-gray-500"
+                      aria-label="Afficher les options"
+                    >
                       <MoreVertical size={16} />
                     </button>
                   </td>
@@ -233,7 +239,10 @@ const Suppliers: React.FC = () => {
                     2 450 €
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
-                    <button className="text-gray-400 hover:text-gray-500">
+                    <button
+                      className="text-gray-400 hover:text-gray-500"
+                      aria-label="Afficher les options"
+                    >
                       <MoreVertical size={16} />
                     </button>
                   </td>


### PR DESCRIPTION
## Summary
- label menu buttons in supplier and invoice tables
- provide descriptive labels for multiple icon-only actions
- add ARIA labels for assistant controls and progress steps

## Testing
- `npm test` (fails: expected +0 to be close to 4)
- `npm run lint` (fails: React Hook "useState" is called conditionally)

------
https://chatgpt.com/codex/tasks/task_e_6892504840ec832588e1e2de71957f59