### PR TITLE
feat: handle closing task status updates

### DIFF
--- a/src/lib/api/closing.ts
+++ b/src/lib/api/closing.ts
@@ -1,0 +1,10 @@
+import { supabase } from '../supabase';
+
+export async function updateClosingTaskStatus(taskId: string, status: string) {
+  const { error } = await supabase
+    .from('closing_tasks')
+    .update({ status })
+    .eq('id', taskId);
+
+  if (error) throw error;
+}

--- a/src/pages/MonthlyClosing.tsx
+++ b/src/pages/MonthlyClosing.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { useToast } from '../contexts/ToastContext';
 import { useClosingTasks } from '../lib/hooks/useClosingTasks';
+import { updateClosingTaskStatus } from '../lib/api/closing';
 
 // Define the steps for the monthly closing process
 const closingSteps = [
@@ -91,11 +92,16 @@ const MonthlyClosing: React.FC = () => {
     }
   }, [fetchedTasks]);
 
-  const updateTaskStatus = (taskId: string, newStatus: Task['status']) => {
-    setTasks(tasks.map(task =>
-      task.id === taskId ? { ...task, status: newStatus } : task
-    ));
-    addToast('Statut de la tâche mis à jour', 'success');
+  const updateTaskStatus = async (taskId: string, newStatus: Task['status']) => {
+    try {
+      await updateClosingTaskStatus(taskId, newStatus);
+      setTasks(tasks.map(task =>
+        task.id === taskId ? { ...task, status: newStatus } : task
+      ));
+      addToast('Statut de la tâche mis à jour', 'success');
+    } catch (error) {
+      addToast("Erreur lors de la mise à jour du statut de la tâche", 'error');
+    }
   };
 
   const getTaskStatusIcon = (status: Task['status']) => {


### PR DESCRIPTION
## Summary
- add API service to update closing task status
- use service in MonthlyClosing page with toast feedback and error handling

## Testing
- `npx vitest run`
- `npm run lint` *(fails: React Hooks must be called in the exact same order)*

------
https://chatgpt.com/codex/tasks/task_e_6892503ffbc48325956f45d02d8fdea0